### PR TITLE
Onestop scanning implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import {onOpen} from './main/menu'
 
+export * from './main/scan'
+
 // Re-export all the exports from `menu` module into Webpack `globalThis` scope, so they are available at runtime
 // for the Google Apps Script to call.
 export * from './main/menu'

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -48,7 +48,9 @@ export function getAllSpreadsheetTabs(): Sheet[] {
 export function getActiveDailyTabs(spreadsheetTabs: Sheet[]): Sheet[] {
     const dailyActiveTabs: Sheet[] = [];
     for(const tab of spreadsheetTabs) {
-        checkIfActiveDailyTab(tab, dailyActiveTabs);
+        if(isActiveDailyTab(tab)) {
+            dailyActiveTabs.push(tab);
+        }
     }
 
     return dailyActiveTabs;
@@ -78,12 +80,10 @@ export function getRowsWithEvents(spreadsheetTab: Sheet): Row[] {
  * Checks if a given tab is not hidden and is a daily tab. If it is, add it to the dailyActiveTabs output array
  * 
  * @param tab the tab to check
- * @param dailyActiveTabs output array to add the tab to if it meets the criteria of not being hidden and being a daily tab
+ * @returns boolean representing the tab is an active and daily tab
  */
-function checkIfActiveDailyTab(tab: Sheet, dailyActiveTabs: Sheet[]): void {
-    if(!isTabHidden(tab) && isDailyTab(tab)) {
-        dailyActiveTabs.push(tab);
-    }
+function isActiveDailyTab(tab: Sheet): boolean {
+    return !isTabHidden(tab) && isDailyTab(tab);
 }
 
 /**
@@ -193,13 +193,14 @@ function processRow(rowData: CellData[], rows: Row[], currentDate: Date): void {
 
 /**
  * Determines if a given row is a valid event row. A row is considered a valid event row if the first two columns contain Date objects
- * and the row has not been crossed out (strikethrough)
+ * and and the what column is not empty and the row has not been crossed out (strikethrough)
  * 
  * @param rowData data for this row
  * @returns boolean representing whether the given row is a valid event row
  */
 function isValidEventRow(rowData: CellData[]): boolean {
-    return rowData[START_TIME_COL_INDEX].value instanceof Date && rowData[END_TIME_COL_INDEX].value instanceof Date && !isRowStrikethrough(rowData);
+    return rowData[START_TIME_COL_INDEX].value instanceof Date && rowData[END_TIME_COL_INDEX].value instanceof Date 
+    && rowData[WHAT_COL_INDEX].value != "" && !isRowStrikethrough(rowData);
 }
 
 /**

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -1,0 +1,103 @@
+type Range = GoogleAppsScript.Spreadsheet.Range;
+type TextStyle = GoogleAppsScript.Spreadsheet.TextStyle;
+type RichTextValue = GoogleAppsScript.Spreadsheet.RichTextValue;
+const dailyTabPattern = /^(MON|TUE|WED|THU|FRI|SAT|SUN) ([1-9]|1[0-2])\/([1-9]|[12][0-9]|3[01])$/;
+
+interface CellData {
+    readonly value: any,
+    readonly linkUrl: string | null,
+    readonly strikethrough: boolean
+}
+
+export function getAllSpreadsheetTabs(): Sheet[] {
+    const spreadsheet: Spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    return spreadsheet.getSheets();
+}
+
+export function getActiveDailyTabs(spreadsheetTabs: Sheet[]): Sheet[] {
+    const dailyActiveTabs: Sheet[] = [];
+    for(const tab of spreadsheetTabs) {
+        const tabName = tab.getName();
+
+        if(!isTabHidden(tab) && isDailyTab(tabName)) {
+            dailyActiveTabs.push(tab);
+        }
+    }
+
+    return dailyActiveTabs;
+}
+
+export function getRowsToProcess(spreadsheetTab: Sheet): Row[] {
+    const dataRange: Range = spreadsheetTab.getDataRange();
+    const cellData = getCellData(dataRange);
+
+    const rows: Row[] = [];
+    for(let i = 0; i < cellData.length; i++) {
+        const rowData: CellData[] = cellData[i];
+        if (isValidEvent(rowData)) {
+            const currentRow: Row = constructRow(rowData);
+            rows.push(currentRow);
+        }
+    }
+
+    return rows;
+}
+
+function isTabHidden(tab: Sheet): boolean {
+    return tab.isSheetHidden();
+}
+
+function isDailyTab(tabName: string): boolean {
+    const matchResult: RegExpMatchArray | null = tabName.match(dailyTabPattern);
+    // null indicates that the tab name did not match the regex pattern for the daily tab
+    return matchResult !== null;
+}
+
+function getCellData(dataRange: Range): CellData[][] {
+    const cellData: CellData[][] = [];
+    const cellValues: any[][] = dataRange.getValues();
+    const cellRichTextData: RichTextValue[][] = dataRange.getRichTextValues() as RichTextValue[][];
+
+    const numRows = dataRange.getNumRows();
+    const numCols = dataRange.getNumColumns();
+
+    for(let i = 0; i < numRows; i++) {
+        cellData[i] = [];
+        for(let j = 0; j < numCols; j++) {
+            const textStyle: TextStyle = cellRichTextData[i][j].getTextStyle();
+            cellData[i][j] = {
+                value: cellValues[i][j],
+                linkUrl: cellRichTextData[i][j].getLinkUrl(),
+                strikethrough: textStyle.isStrikethrough() !== null ? textStyle.isStrikethrough() as boolean : false,
+            }
+        }
+    }
+
+    return cellData;
+}
+
+function isValidEvent(rowData: CellData[]): boolean {
+    // Strikethrough check only happens on the first cell in the row
+    return rowData[0].value instanceof Date && rowData[1].value instanceof Date && !isStrikethrough(rowData);
+}
+
+function isStrikethrough(rowData: CellData[]): boolean {
+    const strikethroughValues = rowData.map((cellData) => cellData.value !== "" && cellData.strikethrough);
+    return strikethroughValues.reduce((curr, next) => curr || next, false);
+}
+
+function constructRow(rowData: CellData[]): Row {
+    return {
+        startTime: rowData[0].value,
+        endTime: rowData[1].value,
+        who: rowData[2].value,
+        numAttendees: rowData[3].value,
+        what: {value: rowData[4].value, hyperlink: rowData[4].linkUrl},
+        where: {value: rowData[5].value, hyperlink: rowData[5].linkUrl},
+        inCharge: {value: rowData[6].value, hyperlink: rowData[6].linkUrl},
+        helpers: {value: rowData[7].value, hyperlink: rowData[7].linkUrl},
+        foodLead: {value: rowData[8].value, hyperlink: rowData[8].linkUrl},
+        childcare: {value: rowData[9].value, hyperlink: rowData[9].linkUrl},
+        notes: {value: rowData[10].value, hyperlink: rowData[10].linkUrl}
+    };
+}

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -2,7 +2,10 @@ type Range = GoogleAppsScript.Spreadsheet.Range;
 type TextStyle = GoogleAppsScript.Spreadsheet.TextStyle;
 type RichTextValue = GoogleAppsScript.Spreadsheet.RichTextValue;
 
-const dailyTabPattern: RegExp = /^(MON|TUE|WED|THU|FRI|SAT|SUN) ([1-9]|1[0-2])\/([1-9]|[12][0-9]|3[01])$/;
+// RegEx pattern used to identify daily tabs
+const DAILY_TAB_REGEX_PATTERN: RegExp = /^(MON|TUE|WED|THU|FRI|SAT|SUN) ([1-9]|1[0-2])\/([1-9]|[12][0-9]|3[01])$/;
+
+// Column indices for event rows
 const DATE_ROW_INDEX: number = 0;
 const DATE_COL_INDEX: number = 0;
 const START_TIME_COL_INDEX: number = 0;
@@ -16,6 +19,8 @@ const HELPERS_COL_INDEX: number = 7;
 const FOOD_LEAD_COL_INDEX: number = 8;
 const CHILDCARE_COL_INDEX: number = 9;
 const NOTES_COL_INDEX: number = 10;
+
+// Number of minutes in an hour
 const MIN_IN_HOUR: number = 60;
 
 interface CellData {
@@ -24,24 +29,41 @@ interface CellData {
     readonly strikethrough: boolean
 }
 
+/**
+ * Fetches all of the tabs of the active spreadsheet
+ *
+ * @returns an array of spreadsheet tabs
+ */
 export function getAllSpreadsheetTabs(): Sheet[] {
     const spreadsheet: Spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
     return spreadsheet.getSheets();
 }
 
+/**
+ * Fetches all of the active, non-hidden, daily tabs from an array of spreadsheet tabs
+ * 
+ * @param spreadsheetTabs array of spreadsheet tabs to search through
+ * @returns array of active daily tabs
+ */
 export function getActiveDailyTabs(spreadsheetTabs: Sheet[]): Sheet[] {
     const dailyActiveTabs: Sheet[] = [];
     for(const tab of spreadsheetTabs) {
-        addDailyActiveTabs(tab, dailyActiveTabs);
+        checkIfActiveDailyTab(tab, dailyActiveTabs);
     }
 
     return dailyActiveTabs;
 }
 
-export function getRowsToProcess(spreadsheetTab: Sheet): Row[] {
+/**
+ * Fetches the rows from a spreadsheet tab that correspond to an actual event on the Onestop
+ * 
+ * @param spreadsheetTab spreadsheet tab to search through
+ * @returns an array of Row objects
+ */
+export function getRowsWithEvents(spreadsheetTab: Sheet): Row[] {
     const dataRange: Range = spreadsheetTab.getDataRange();
     const cellData = getCellData(dataRange);
-    const currentDate = getDate(cellData);
+    const currentDate = getDateOfDailyTab(cellData);
 
     const rows: Row[] = [];
     for(let i = 0; i < cellData.length; i++) {
@@ -52,23 +74,47 @@ export function getRowsToProcess(spreadsheetTab: Sheet): Row[] {
     return rows;
 }
 
-function addDailyActiveTabs(tab: Sheet, dailyActiveTabs: Sheet[]): void {
+/**
+ * Checks if a given tab is not hidden and is a daily tab. If it is, add it to the dailyActiveTabs output array
+ * 
+ * @param tab the tab to check
+ * @param dailyActiveTabs output array to add the tab to if it meets the criteria of not being hidden and being a daily tab
+ */
+function checkIfActiveDailyTab(tab: Sheet, dailyActiveTabs: Sheet[]): void {
     if(!isTabHidden(tab) && isDailyTab(tab)) {
         dailyActiveTabs.push(tab);
     }
 }
 
+/**
+ * Checks if a given tab is hidden
+ * 
+ * @param tab the tab to check
+ * @returns boolean representing whether the tab is hidden or not
+ */
 function isTabHidden(tab: Sheet): boolean {
     return tab.isSheetHidden();
 }
 
+/**
+ * Checks if a given tab is a daily tab using RegEx. The tab name must meet the general pattern of DDD M/dd (ex. TUE 8/13) to be considered a daily tab
+ * 
+ * @param tab the tab to check
+ * @returns boolean representing whether the tab is a daily tab or not
+ */
 function isDailyTab(tab: Sheet): boolean {
     const tabName: string = tab.getName();
-    const matchResult: RegExpMatchArray | null = tabName.match(dailyTabPattern);
+    const matchResult: RegExpMatchArray | null = tabName.match(DAILY_TAB_REGEX_PATTERN);
     // null indicates that the tab name did not match the regex pattern for the daily tab
     return matchResult !== null;
 }
 
+/**
+ * Fetches all of the cell data for a given range of cells on a spreadsheet
+ * 
+ * @param dataRange the range of cells to fetch data for
+ * @returns matrix of CellData objects
+ */
 function getCellData(dataRange: Range): CellData[][] {
     const cellData: CellData[][] = [];
     const cellValues: any[][] = dataRange.getValues();
@@ -85,6 +131,15 @@ function getCellData(dataRange: Range): CellData[][] {
     return cellData;
 }
 
+/**
+ * Helper function for the getCellData function that given a row, populates the column data for that particular row
+ * 
+ * @param currentRow the current row index being processed
+ * @param cellData output matrix where the column data is to be populated
+ * @param numCols number of columns in the cell data matrix
+ * @param cellRichTextData rich text data that is to be used to fetch the potential hyperlink urls for cells in this row
+ * @param cellValues actual data values that is to be used to populate the cell data matrix
+ */
 function populateColumnData(currentRow: number, cellData: CellData[][], numCols: number, cellRichTextData: RichTextValue[][], cellValues: any[][]) {
     for(let j = 0; j < numCols; j++) {
         const textStyle: TextStyle = cellRichTextData[currentRow][j].getTextStyle();
@@ -96,11 +151,25 @@ function populateColumnData(currentRow: number, cellData: CellData[][], numCols:
     }
 }
 
+/**
+ * Returns whether a cell has strikethrough set
+ * 
+ * @param textStyle style object for a particular cell
+ * @returns the strikethrough value of the cell if it is not null, otherwise defaults to false
+ */
 function getCellStrikethrough(textStyle: TextStyle): boolean {
     return textStyle.isStrikethrough() !== null ? textStyle.isStrikethrough() as boolean : false;
 }
 
-function getDate(cellData: CellData[][]): Date {
+/**
+ * Retrieves the date for a particular daily tab. For a daily tab, the date is located in the top left cell. Because Google Sheets stores 
+ * our Date values in local time and the Google Apps Script API attempts to readjust these Date values assuming they are in UTC, we must 
+ * re-add the UTC offset in order get back to local time (PDT)
+ * 
+ * @param cellData cell data for this particular tab
+ * @returns Date object containing the date information for this daily tab
+ */
+function getDateOfDailyTab(cellData: CellData[][]): Date {
     const date: Date = cellData[DATE_ROW_INDEX][DATE_COL_INDEX].value;
     const utcHoursOffset = getUTCHoursOffset(date);
     date.setHours(date.getHours() + utcHoursOffset);
@@ -108,24 +177,58 @@ function getDate(cellData: CellData[][]): Date {
     return date;
 }
 
+/**
+ * Processes a row by checking if the row is a valid event row. If it is, a Row object is constructed and added to the output array
+ * 
+ * @param rowData array of CellData objects representing the data for a row
+ * @param rows output array of all the rows
+ * @param currentDate current date object used to construct the Date objects for a new Row
+ */
 function processRow(rowData: CellData[], rows: Row[], currentDate: Date): void {
-    if (isValidRow(rowData)) {
+    if (isValidEventRow(rowData)) {
         const currentRow: Row = constructRow(rowData, currentDate);
         rows.push(currentRow);
     }
 }
 
-function isValidRow(rowData: CellData[]): boolean {
+/**
+ * Determines if a given row is a valid event row. A row is considered a valid event row if the first two columns contain Date objects
+ * and the row has not been crossed out (strikethrough)
+ * 
+ * @param rowData data for this row
+ * @returns boolean representing whether the given row is a valid event row
+ */
+function isValidEventRow(rowData: CellData[]): boolean {
     return rowData[START_TIME_COL_INDEX].value instanceof Date && rowData[END_TIME_COL_INDEX].value instanceof Date && !isRowStrikethrough(rowData);
 }
 
+/**
+ * Determines whether a given row has been crossed out (strikethrough) or not. A row is considered crossed out if all cells in the row that have
+ * text have their strikethrough property set to true. The first Date objects in the first two columns are ignored as their strikethrough values
+ * are always set as false according to the Google Apps Script api
+ * 
+ * @param rowData data for this row
+ * @returns boolean representing whether the given row has been crossed out or not
+ */
 function isRowStrikethrough(rowData: CellData[]): boolean {
+    // Filters out all cells without any values
     // Need to skip the time columns because their strikethrough values are incorrectly returned by the TextStyle object
     const nonEmptyCells: CellData[] = rowData.filter((cellData, index) => cellData.value !== "" && index > END_TIME_COL_INDEX);
+
+    // Extracts only the strikethrough values from the CellData objects
     const strikethroughValues = nonEmptyCells.map((cellData) => cellData.strikethrough);
+
+    // Incrementally ands all of the strikethrough values together
     return strikethroughValues.reduce((curr, next) => curr && next, true);
 }
 
+/**
+ * Given the data for a row, construct and return a corresponding Row object
+ * 
+ * @param rowData the data for the row
+ * @param currentDate Date object containing the current date
+ * @returns Row object that holds all of the data for the given row
+ */
 function constructRow(rowData: CellData[], currentDate: Date): Row {
     const startTime: Date = rowData[START_TIME_COL_INDEX].value;
     const endTime: Date = rowData[END_TIME_COL_INDEX].value;
@@ -145,9 +248,19 @@ function constructRow(rowData: CellData[], currentDate: Date): Row {
     };
 }
 
+/**
+ * Given two Date objects representing the current date and the current time, returns a Date object that combines the two.
+ * The resulting Date object should have both the current date and time set appropriately
+ * 
+ * @param currentDate Date object containing the current date
+ * @param currentTime Date object containing the current time
+ * @returns Date object containing the current date and time
+ */
 function constructDate(currentDate: Date, currentTime: Date): Date {
     const timezoneOffset: number = getUTCHoursOffset(currentTime);
     const combinedDate = new Date();
+
+    // First set the time in case adding the timezoneOffset causes the date to rollover
     combinedDate.setHours(currentTime.getHours() + timezoneOffset);
     combinedDate.setMinutes(currentTime.getMinutes());
     combinedDate.setSeconds(currentTime.getSeconds());
@@ -161,6 +274,12 @@ function constructDate(currentDate: Date, currentTime: Date): Date {
     return combinedDate;
 }
 
+/**
+ * Retrieves the offset from UTC time in hours
+ * 
+ * @param date Date object to retrieve the offset from UTC time from
+ * @returns offset from UTC time in hours
+ */
 function getUTCHoursOffset(date: Date): number {
     return date.getTimezoneOffset() / MIN_IN_HOUR;
 }

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -8,12 +8,12 @@ declare interface OpenEvent {
 type Spreadsheet = GoogleAppsScript.Spreadsheet.Spreadsheet;
 type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
 
-interface Text {
+declare interface Text {
   readonly value: string,
   readonly hyperlink: string | null
 }
 
-interface Row {
+declare interface Row {
   readonly startTime: Date,
   readonly endTime: Date,
   readonly who: string,

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -4,3 +4,25 @@ declare interface OpenEvent {
   readonly triggerUid?: string,
   readonly user?: GoogleAppsScript.Base.User
 }
+
+type Spreadsheet = GoogleAppsScript.Spreadsheet.Spreadsheet;
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+
+interface Text {
+  readonly value: string,
+  readonly hyperlink: string | null
+}
+
+interface Row {
+  readonly startTime: Date,
+  readonly endTime: Date,
+  readonly who: string,
+  readonly numAttendees: number,
+  readonly what: Text,
+  readonly where: Text,
+  readonly inCharge: Text,
+  readonly helpers: Text,
+  readonly foodLead: Text,
+  readonly childcare: Text,
+  readonly notes: Text
+}


### PR DESCRIPTION
Draft PR that contains the initial implementation for scanning the Onestop for daily tabs and lines to process within those daily active tabs. This PR is admittedly pretty big and there is definitely some more work to be done with regards to efficiency and cleanup, however it is functional at the moment.

Publicly exposed functions:
* `getAllSpreadsheetTabs(): Sheet[]`
* `getActiveDailyTabs(spreadsheetTabs: Sheet[]): Sheet[]`
* `getRowsWithEvents(spreadsheetTab: Sheet): Row[]`

Added types:
* `Spreadsheet`
* `Sheet`
* `Text`
* `Row`