### PR TITLE
Add row unique identifiers to metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^9.9.0",
     "eslint-webpack-plugin": "^4.2.0",
     "gas-webpack-plugin": "^2.6.0",
+    "ts-loader": "^9.5.1",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.1.0",
     "webpack": "^5.93.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-import {onOpen} from './main/menu'
+import {onOpen} from './main/menu';
 
-export * from './main/basecamp'
-export * from './main/scan'
+export * from './main/basecamp';
+export * from './main/metadata';
+export * from './main/scan';
 
 // Re-export all the exports from `menu` module into Webpack `globalThis` scope, so they are available at runtime
 // for the Google Apps Script to call.
-export * from './main/menu'
+export * from './main/menu';
 
 // Assign `global` so gas-webpack-plugin will generate a stub for `onOpen` in the top-level scope. A top-level
 // declaration is needed for Google Apps Script to detect the function, so it is available as a trigger.
-global.onOpen = onOpen
+global.onOpen = onOpen;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import {onOpen} from './main/menu';
 
 export * from './main/basecamp';
-export * from './main/metadata';
+export * from './main/row';
 export * from './main/scan';
 
 // Re-export all the exports from `menu` module into Webpack `globalThis` scope, so they are available at runtime

--- a/src/main/metadata.ts
+++ b/src/main/metadata.ts
@@ -27,8 +27,15 @@ export function getMetadata(range: Range): Metadata {
  * @param row the Row to retrieve the unique id for
  * @returns unique id for the row; null if one has not been set
  */
-export function getRowUniqueId(row: Row): string | null {
-    return row.metadata.getValue();
+export function getId(row: Row): string {
+    const id = row.metadata.getValue();
+
+    if(id === null) {
+        throw Error(`Row does not have an id: [${row.startTime}, ${row.endTime}, ${row.who}, 
+            ${row.what.value}, ${row.where.value}, ${row.inCharge.value}, ${row.helpers.value}]`);
+    }
+
+    return id;
 }
 
 /**
@@ -37,7 +44,7 @@ export function getRowUniqueId(row: Row): string | null {
  * @param row the row to assign a new unique id to
  * @returns the new unique id
  */
-export function assignRowUniqueId(row: Row): string {
+export function assignId(row: Row): string {
     const newId: string = Utilities.getUuid();
     row.metadata.setValue(newId);
     return newId;
@@ -49,6 +56,6 @@ export function assignRowUniqueId(row: Row): string {
  * @param row the row to check the unique id of
  * @returns boolean representing whether a given Row has been assigned a unique id or not
  */
-export function rowHasUniqueId(row: Row): boolean {
-    return getRowUniqueId(row) !== null;
+export function hasId(row: Row): boolean {
+    return row.metadata.getValue() !== null;
 }

--- a/src/main/metadata.ts
+++ b/src/main/metadata.ts
@@ -1,0 +1,54 @@
+const ROW_ID_KEY: string = "rowId";
+
+/**
+ * Retrieves the metadata object for a given range. If the metadata object does not exist,
+ * this function will set the row id key so the metadata object is created and a reference
+ * can be held
+ * 
+ * @param range Range representing an event row
+ * @returns reference to the Metadata object for this row
+ */
+export function getMetadata(range: Range): Metadata {
+    let metadataList: Metadata[] = range.getDeveloperMetadata();
+
+    if (metadataList.length === 0) {
+        // Add the row id key so the metadata object is created
+        range.addDeveloperMetadata(ROW_ID_KEY);
+        metadataList = range.getDeveloperMetadata();
+    }
+
+    return metadataList[0];
+}
+
+/**
+ * Retrieves the unique id for a Row. The unique id is stored in the value of the metadata.
+ * If the unique id has not been set, null will be returned
+ * 
+ * @param row the Row to retrieve the unique id for
+ * @returns unique id for the row; null if one has not been set
+ */
+export function getRowUniqueId(row: Row): string | null {
+    return row.metadata.getValue();
+}
+
+/**
+ * Assigns a new unique id to a row
+ * 
+ * @param row the row to assign a new unique id to
+ * @returns the new unique id
+ */
+export function assignRowUniqueId(row: Row): string {
+    const newId: string = Utilities.getUuid();
+    row.metadata.setValue(newId);
+    return newId;
+}
+
+/**
+ * Returns a boolean representing whether a given Row has been assigned a unique id or not
+ * 
+ * @param row the row to check the unique id of
+ * @returns boolean representing whether a given Row has been assigned a unique id or not
+ */
+export function rowHasUniqueId(row: Row): boolean {
+    return getRowUniqueId(row) !== null;
+}

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -38,12 +38,12 @@ export function getId(row: Row): string {
 }
 
 /**
- * Assigns a new unique id to a row
+ * Generates a new unique id for a row
  * 
- * @param row the row to assign a new unique id to
+ * @param row the row to generate a new unique id for
  * @returns the new unique id
  */
-export function assignId(row: Row): string {
+export function generateIdForRow(row: Row): string {
     const newId: string = Utilities.getUuid();
     row.metadata.setValue(newId);
     return newId;

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -66,6 +66,7 @@ export function hasId(row: Row): boolean {
  * @returns string representation of the given row
  */
 function toString(row: Row): string {
-    return `[${row.startTime}, ${row.endTime}, ${row.who}, ${row.what.value}, ${row.where.value}, 
-    ${row.inCharge.value}, ${row.helpers.value}]`;
+    return `[${row.startTime}, ${row.endTime}, ${row.who}, ${row.numAttendees}, ${row.what.value}, 
+    ${row.where.value}, ${row.inCharge.value}, ${row.helpers.value}, ${row.foodLead.value}, 
+    ${row.childcare.value}, ${row.notes.value}]`;
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -31,8 +31,7 @@ export function getId(row: Row): string {
     const id = row.metadata.getValue();
 
     if(id === null) {
-        throw Error(`Row does not have an id: [${row.startTime}, ${row.endTime}, ${row.who}, 
-            ${row.what.value}, ${row.where.value}, ${row.inCharge.value}, ${row.helpers.value}]`);
+        throw Error("Row does not have an id: " + toString(row));
     }
 
     return id;
@@ -58,4 +57,15 @@ export function assignId(row: Row): string {
  */
 export function hasId(row: Row): boolean {
     return row.metadata.getValue() !== null;
+}
+
+/**
+ * Returns a string representation of the given row
+ * 
+ * @param row the row to return a string representation for
+ * @returns string representation of the given row
+ */
+function toString(row: Row): string {
+    return `[${row.startTime}, ${row.endTime}, ${row.who}, ${row.what.value}, ${row.where.value}, 
+    ${row.inCharge.value}, ${row.helpers.value}]`;
 }

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -1,4 +1,4 @@
-import { getMetadata } from "./metadata";
+import { getMetadata } from "./row";
 
 type TextStyle = GoogleAppsScript.Spreadsheet.TextStyle;
 type RichTextValue = GoogleAppsScript.Spreadsheet.RichTextValue;

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -7,6 +7,8 @@ declare interface OpenEvent {
 
 type Spreadsheet = GoogleAppsScript.Spreadsheet.Spreadsheet;
 type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+type Range = GoogleAppsScript.Spreadsheet.Range;
+type Metadata = GoogleAppsScript.Spreadsheet.DeveloperMetadata;
 
 declare interface Text {
   readonly value: string,
@@ -14,6 +16,7 @@ declare interface Text {
 }
 
 declare interface Row {
+  readonly metadata: Metadata,
   readonly startTime: Date,
   readonly endTime: Date,
   readonly who: string,


### PR DESCRIPTION
## Description
Adds the ability to add unique identifiers to rows via [metadata](https://developers.google.com/sheets/api/guides/metadata) as part of https://3.basecamp.com/4474129/buckets/38736474/todos/772966216. Metadata for google sheets allows for a key and a value to be associated with each row independently (the key and value are not tied to each other like they are in a traditional map).
When the scanning of the Onestop rows occurs, a Metadata object is created for each valid event row by setting the key (this causes Google Sheets to create the Metadata object). The value of the Metadata object contains the unique id of the Row. If it is `null`, this indicates it's unique has not yet been assigned indicating the row is new. These unique ids are tied to the specific row and will stay with the row even if the row is moved around in the spreadsheet tab.

## Changes
* Re-added `ts-loader` dependency that was removed as part of #3 as it is required to compile TS with webpack
* Added functions that allow checking, assigning, and retrieving unique ids for rows via metadata
* Adds a metadata field to the Row interface
* Removes a function with an output parameter which we are trying to avoid (added as part of #2 )