### PR TITLE
Core logic create todo new row

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {onOpen} from './main/menu';
 
 export * from './main/basecamp';
+export * from './main/main';
 export * from './main/people';
 export * from './main/propertiesService';
 export * from './main/row';

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -1,30 +1,35 @@
 import { BASECAMP_CLIENT_ID, BASECAMP_CLIENT_SECRET } from "../../config/environmentVariables";
 
-const BASECAMP_AUTH_URL = 'https://launchpad.37signals.com/authorization/new?type=web_server';
-const BASECAMP_TOKEN_URL = 'https://launchpad.37signals.com/authorization/token?type=web_server';
-const BASECAMP_AUTH_CHECK_URL = 'https://launchpad.37signals.com/authorization.json';
-const OAUTH_BASECAMP_SERVICE_NAME = 'Basecamp';
-const OAUTH_CALLBACK_FUNCTION_NAME = 'oauthCallback'
-const BASECAMP_UNAUTH_ERROR_MSG = 'Basecamp not authenticated. Please try again.';
-const AUTH_DIALOG_MSG = 'You are disconnected from Basecamp. Copy the following link on a new tab to be authorized:\n\n';
-const AUTH_SUCCESS_HTML = 'Connection with Basecamp was successful! You can close this tab and re-run the program.';
-const AUTH_FAIL_HTML = 'Connection denied. Please close this tab and try again.';
-const LINK_HEADER_MISSING_ERROR_MSG = 'Next URL from Link header is undefined';
+type HttpMethod = GoogleAppsScript.URL_Fetch.HttpMethod;
 
-const HEADER_AUTHORIZATION = 'Authorization';
-const HEADER_BEARER_TOKEN = 'Bearer ';
-const HEADER_USER_AGENT = 'User-Agent';
-const HEADER_USER_AGENT_NAME = 'Google App Script Onestop Basecamp Integration';
-const HEADER_CONTENT_TYPE = 'Content-Type';
-const HEADER_JSON_CONTENT_TYPE = 'application/json';
+const BASECAMP_AUTH_URL: string = 'https://launchpad.37signals.com/authorization/new?type=web_server';
+const BASECAMP_TOKEN_URL: string = 'https://launchpad.37signals.com/authorization/token?type=web_server';
+const BASECAMP_AUTH_CHECK_URL: string = 'https://launchpad.37signals.com/authorization.json';
+const OAUTH_BASECAMP_SERVICE_NAME: string = 'Basecamp';
+const OAUTH_CALLBACK_FUNCTION_NAME: string = 'oauthCallback'
+const BASECAMP_UNAUTH_ERROR_MSG: string = 'Basecamp not authenticated. Please try again.';
+const AUTH_DIALOG_MSG: string = 'You are disconnected from Basecamp. Copy the following link on a new tab to be authorized:\n\n';
+const AUTH_SUCCESS_HTML: string = 'Connection with Basecamp was successful! You can close this tab and re-run the program.';
+const AUTH_FAIL_HTML: string = 'Connection denied. Please close this tab and try again.';
+const LINK_HEADER_MISSING_ERROR_MSG: string = 'Next URL from Link header is undefined';
 
-const HTTP_POST_METHOD = 'post';
-const HTTP_PUT_METHOD = 'put'
-const HTTP_GET_METHOD = 'get'
+const HEADER_AUTHORIZATION: string = 'Authorization';
+const HEADER_BEARER_TOKEN: string = 'Bearer ';
+const HEADER_USER_AGENT: string = 'User-Agent';
+const HEADER_USER_AGENT_NAME: string = 'Google App Script Onestop Basecamp Integration';
+const HEADER_CONTENT_TYPE: string = 'Content-Type';
+const HEADER_JSON_CONTENT_TYPE: string = 'application/json';
 
-const BASECAMP_API_URL = 'https://3.basecampapi.com';
-const A2N_BASECAMP_ORG_ID = '4474129';
-const BUCKETS_PATH = '/buckets/'
+const HTTP_POST_METHOD: HttpMethod = 'post';
+const HTTP_PUT_METHOD: HttpMethod = 'put';
+const HTTP_GET_METHOD: HttpMethod = 'get';
+
+const BASECAMP_API_URL: string = 'https://3.basecampapi.com';
+const A2N_BASECAMP_ORG_ID: string = '4474129';
+const BUCKETS_PATH: string = '/buckets/';
+// Project ID hardcoded to our SD Basecamp Integration project for testing
+// In the future we may consider moving this to a script property as a config value
+export const PROJECT_ID: string = "38736474";
 
 /**
  * Gets the Basecamp URL for a specific project

--- a/src/main/error/propertiesServiceDeleteError.ts
+++ b/src/main/error/propertiesServiceDeleteError.ts
@@ -1,0 +1,9 @@
+export class PropertiesServiceDeleteError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PropertiesServiceDeleteError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, PropertiesServiceDeleteError.prototype);
+    }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,7 +12,7 @@ const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
  * Main entry point for the Onestop to Basecamp Integration that contains the core logic for
  * adding/updating/deleting Basecamp Todos based on the rows on the Onestop
  */
-export function main(): void {
+export function importOnestopToBascamp(): void {
     const eventRows: Row[] = getEventRowsFromSpreadsheet();
     const processedRowIds: string[] = [];
 
@@ -35,7 +35,7 @@ function processExistingRow(row: Row): void {
 
 /**
  * Processes new event rows by creating a new Basecamp Todo for each of the roles associated with that 
- * particular event row. If at least on Todo is creaed in Bascamp, the row is saved for easier retrieval
+ * particular event row. If at least on Todo is created in Bascamp, the row is saved for easier retrieval
  * and updating later
  * 
  * @param row 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,7 +12,7 @@ const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
  * Main entry point for the Onestop to Basecamp Integration that contains the core logic for
  * adding/updating/deleting Basecamp Todos based on the rows on the Onestop
  */
-export function importOnestopToBascamp(): void {
+export function importOnestopToBasecamp(): void {
     const eventRows: Row[] = getEventRowsFromSpreadsheet();
     const processedRowIds: string[] = [];
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,6 @@
 import { PROJECT_ID } from "./basecamp";
-import { generateIdForRow, getBasecampTodoForLeads, getBasecampTodosForHelpers, getId, hasId, saveRow } from "./row";
-import { getActiveDailyTabs, getAllSpreadsheetTabs, getRowsWithEvents } from "./scan";
+import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasId, saveRow } from "./row";
+import { getEventRowsFromSpreadsheet } from "./scan";
 import { createTodo, TODOLIST_ID } from "./todos";
 
 const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
@@ -8,12 +8,11 @@ const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
     todolistId: TODOLIST_ID
 };
 
+/**
+ * 
+ */
 export function main(): void {
-    const tabs: Sheet[] = getAllSpreadsheetTabs();
-    const dailyActiveTabs: Sheet[] = getActiveDailyTabs(tabs);
-    
-    // Fetches all event rows from all of the daily active tabs
-    const eventRows: Row[] = dailyActiveTabs.flatMap((dailyActiveTab) => getRowsWithEvents(dailyActiveTab));
+    const eventRows: Row[] = getEventRowsFromSpreadsheet();
     const processedRowIds: string[] = [];
 
     for(const eventRow of eventRows) {
@@ -30,24 +29,28 @@ export function main(): void {
 }
 
 function processExistingRow(row: Row): void {
-
+    // Will be implemented as part of https://3.basecamp.com/4474129/buckets/38736474/todos/7717428992
 }
 
+/**
+ * 
+ * 
+ * @param row 
+ */
 function processNewRow(row: Row): void {
-    const leadsBasecampTodoRequest: BasecampTodoRequest | undefined = getBasecampTodoForLeads(row);
-    const helpersBasecampTodoRequest: BasecampTodoRequest[] = getBasecampTodosForHelpers(row);
-
-    if(leadsBasecampTodoRequest !== undefined) {
-        helpersBasecampTodoRequest.push(leadsBasecampTodoRequest);
-    }
-
-    const basecampTodoIds: string[] = addNewTodos(helpersBasecampTodoRequest);
+    const basecampTodoRequests: BasecampTodoRequest[] = getBasecampTodoRequestsForRow(row);
+    const basecampTodoIds: string[] = createNewTodos(basecampTodoRequests);
 
     generateIdForRow(row);
     saveRow(row, basecampTodoIds);
 }
 
-function addNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
+/**
+ * 
+ * @param basecampRequests 
+ * @returns 
+ */
+function createNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
     const basecampTodoIds: string[] = [];
     for(const request of basecampRequests) {
         basecampTodoIds.push(createTodo(request, DEFAULT_TODOLIST_IDENTIFIER));
@@ -57,5 +60,5 @@ function addNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
 }
 
 function deleteOldRows(processedRowIds: string[]): void {
-
+    // Will be implemented as part of https://3.basecamp.com/4474129/buckets/38736474/todos/7762398829
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,0 +1,61 @@
+import { PROJECT_ID } from "./basecamp";
+import { generateIdForRow, getBasecampTodoForLeads, getBasecampTodosForHelpers, getId, hasId, saveRow } from "./row";
+import { getActiveDailyTabs, getAllSpreadsheetTabs, getRowsWithEvents } from "./scan";
+import { createTodo, TODOLIST_ID } from "./todos";
+
+const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
+    projectId: PROJECT_ID,
+    todolistId: TODOLIST_ID
+};
+
+export function main(): void {
+    const tabs: Sheet[] = getAllSpreadsheetTabs();
+    const dailyActiveTabs: Sheet[] = getActiveDailyTabs(tabs);
+    
+    // Fetches all event rows from all of the daily active tabs
+    const eventRows: Row[] = dailyActiveTabs.flatMap((dailyActiveTab) => getRowsWithEvents(dailyActiveTab));
+    const processedRowIds: string[] = [];
+
+    for(const eventRow of eventRows) {
+        if(hasId(eventRow)) {
+            processExistingRow(eventRow);
+        } else {
+            processNewRow(eventRow);
+        }
+
+        processedRowIds.push(getId(eventRow));
+    }
+
+    deleteOldRows(processedRowIds);
+}
+
+function processExistingRow(row: Row): void {
+
+}
+
+function processNewRow(row: Row): void {
+    const leadsBasecampTodoRequest: BasecampTodoRequest | undefined = getBasecampTodoForLeads(row);
+    const helpersBasecampTodoRequest: BasecampTodoRequest[] = getBasecampTodosForHelpers(row);
+
+    if(leadsBasecampTodoRequest !== undefined) {
+        helpersBasecampTodoRequest.push(leadsBasecampTodoRequest);
+    }
+
+    const basecampTodoIds: string[] = addNewTodos(helpersBasecampTodoRequest);
+
+    generateIdForRow(row);
+    saveRow(row, basecampTodoIds);
+}
+
+function addNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
+    const basecampTodoIds: string[] = [];
+    for(const request of basecampRequests) {
+        basecampTodoIds.push(createTodo(request, DEFAULT_TODOLIST_IDENTIFIER));
+    }
+
+    return basecampTodoIds;
+}
+
+function deleteOldRows(processedRowIds: string[]): void {
+
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,8 @@ const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
 };
 
 /**
- * 
+ * Main entry point for the Onestop to Basecamp Integration that contains the core logic for
+ * adding/updating/deleting Basecamp Todos based on the rows on the Onestop
  */
 export function main(): void {
     const eventRows: Row[] = getEventRowsFromSpreadsheet();
@@ -33,7 +34,9 @@ function processExistingRow(row: Row): void {
 }
 
 /**
- * 
+ * Processes new event rows by creating a new Basecamp Todo for each of the roles associated with that 
+ * particular event row. If at least on Todo is creaed in Bascamp, the row is saved for easier retrieval
+ * and updating later
  * 
  * @param row 
  */
@@ -41,14 +44,17 @@ function processNewRow(row: Row): void {
     const basecampTodoRequests: BasecampTodoRequest[] = getBasecampTodoRequestsForRow(row);
     const basecampTodoIds: string[] = createNewTodos(basecampTodoRequests);
 
-    generateIdForRow(row);
-    saveRow(row, basecampTodoIds);
+    if(basecampTodoIds.length > 0) {
+        generateIdForRow(row);
+        saveRow(row, basecampTodoIds);
+    }
 }
 
 /**
+ * Sends requests to create new Basecamp Todos
  * 
- * @param basecampRequests 
- * @returns 
+ * @param basecampRequests array of BasecampTodoRequest objects to send
+ * @returns array of corresponding Basecamp Todo ids
  */
 function createNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
     const basecampTodoIds: string[] = [];

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -1,12 +1,9 @@
-import { getBasecampUrl, sendPaginatedBasecampGetRequest } from "./basecamp";
+import { getBasecampUrl, PROJECT_ID, sendPaginatedBasecampGetRequest } from "./basecamp";
 import { PersonNameIdMapNotCachedError } from "./error/personNameIdMapNotCachedError";
 import { getScriptProperty, setScriptProperty } from "./propertiesService";
 
 type PersonNameIdMap = {[key: string]: string};
 
-// Project ID hardcoded to our SD Basecamp Integration project for testing
-// In the future we may consider moving this to a script property as a config value
-const PROJECT_ID: string = "38736474";
 const PEOPLE_PATH: string = `/projects/${PROJECT_ID}/people.json`;
 const PEOPLE_MAP_KEY: string = "PEOPLE_MAP";
 

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -1,3 +1,4 @@
+import { PropertiesServiceDeleteError } from "./error/propertiesServiceDeleteError";
 import { PropertiesServiceReadError } from "./error/propertiesServiceReadError";
 import { PropertiesServiceWriteError } from "./error/propertiesServiceWriteError";
 
@@ -17,7 +18,7 @@ export function getDocumentProperty(key: string): string | null {
     try {
         value = documentProperties.getProperty(key);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceReadError(`Failed to retrieve document property: [key: ${key}] ${error.message}`);
     }
 
@@ -34,7 +35,7 @@ export function setDocumentProperty(key: string, value: string): void {
     try {
         documentProperties.setProperty(key, value);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceWriteError(`Failed to save to document property PropertiesService: [key: ${key}, value: ${value}] ${error.message}`);
     }
 }
@@ -48,7 +49,7 @@ export function setDocumentProperties(properties: {[key: string]: string}): void
     try {
         documentProperties.setProperties(properties);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceWriteError(`Failed to save to document property PropertiesService: [properties: ${properties}] ${error.message}`);
     }
 }
@@ -64,7 +65,7 @@ export function getScriptProperty(key: string): string | null {
     try {
         value = scriptProperties.getProperty(key);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceReadError(`Failed to retrieve script property: [key: ${key}] ${error.message}`);
     }
 
@@ -81,7 +82,7 @@ export function setScriptProperty(key: string, value: string): void {
     try {
         scriptProperties.setProperty(key, value);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceWriteError(`Failed to save to script property PropertiesService: [key: ${key}, value: ${value}] ${error.message}`);
     }
 }
@@ -95,7 +96,19 @@ export function setScriptProperties(properties: {[key: string]: string}): void {
     try {
         scriptProperties.setProperties(properties);
     } catch (e: any) {
-        const error = e as Error;
+        const error: Error = e as Error;
         throw new PropertiesServiceWriteError(`Failed to save to script property PropertiesService: [properties: ${properties}] ${error.message}`);
+    }
+}
+
+/**
+ * Useful debugging function that will clear all document properties
+ */
+export function deleteAllDocumentProperties(): void {
+    try {
+        documentProperties.deleteAllProperties();
+    } catch (e: any) {
+        const error: Error = e as Error;
+        throw new PropertiesServiceDeleteError(`Failed to delete all document properties: ${error.message}`)
     }
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -190,8 +190,8 @@ export function toString(row: Row): string {
 /**
  * Helper function that transforms a byte array into a hexidecimal string
  * 
- * @param byteArray 
- * @returns 
+ * @param byteArray byte array input
+ * @returns hexidecimal string representation of the byte array
  */
 function toHexString(byteArray: number[]): string {
     return byteArray.map(byte => {
@@ -204,8 +204,11 @@ function toHexString(byteArray: number[]): string {
 }
 
 /**
+ * Retrieves an array of BasecampTodoRequest objects for an event row. BasecampTodoRequest
+ * objects are constructed for both the leads and the helpers
  * 
- * @param row 
+ * @param row Row to construct and retrieve BasecampTodoRequest objects for
+ * @returns array of BasecampTodoRequest objects
  */
 export function getBasecampTodoRequestsForRow(row: Row): BasecampTodoRequest[] {
     let basecampTodoRequests: BasecampTodoRequest[] = [];

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -84,48 +84,16 @@ export function hasId(row: Row): boolean {
  * 
  * @param row the row's contents to write
  */
-export function saveRow(row: Row): void {
+export function saveRow(row: Row, basecampTodoIds: string[]): void {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }
 
     const rowId: string = getId(row);
     const rowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, toString(row)));
-    const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash};
+    const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash, basecampTodoIds: basecampTodoIds};
 
     setDocumentProperty(rowId, JSON.stringify(rowBasecampMapping));
-}
-
-/**
- * Batched version of saveRow() which saves an array of row's contents
- * to the PropertiesService at one time
- * 
- * @param rows array of rows to write
- */
-export function saveRows(rows: Row[]): void {
-    const rowsWithIds: Row[] = rows.filter((row) => {
-        const rowHasId: boolean = hasId(row);
-        if(!rowHasId) {
-            Logger.log(`Row does not have an id: ${toString(row)}`);
-            return false;
-        }
-        return true;
-    });
-
-    if(rowsWithIds.length > 0) {
-        // Constructs an object containing all of the rowId/rowHash pairs to be written
-        const properties: {[key: string]: string} = {};
-        for(const row of rowsWithIds) {
-            const rowId: string = getId(row);
-            const rowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, toString(row)));
-            const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash};
-            properties[rowId] = JSON.stringify(rowBasecampMapping);
-        }
-
-        setDocumentProperties(properties);
-    } else {
-        Logger.log("No rows with ids provided");
-    }
 }
 
 /**

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -78,6 +78,8 @@ export function generateIdForRow(row: Row): string {
 export function hasId(row: Row): boolean {
     const id: string | null = row.metadata.getValue();
 
+    // Creating the metadata object sets the value to the empty string so we need to check for 
+    // that here to determine if the id has been set or not
     return id !== null && id !== "";
 }
 

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -31,7 +31,9 @@ interface CellData {
 }
 
 /**
+ * Retrieves all event rows from the spreadsheet
  * 
+ * @returns an array of event rows from all of the daily active tabs of the spreadsheet
  */
 export function getEventRowsFromSpreadsheet(): Row[] {
     const tabs: Sheet[] = getAllSpreadsheetTabs();

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -31,6 +31,18 @@ interface CellData {
 }
 
 /**
+ * 
+ */
+export function getEventRowsFromSpreadsheet(): Row[] {
+    const tabs: Sheet[] = getAllSpreadsheetTabs();
+    const dailyActiveTabs: Sheet[] = getActiveDailyTabs(tabs);
+    // Fetches all event rows from all of the daily active tabs
+    const eventRows: Row[] = dailyActiveTabs.flatMap((dailyActiveTab) => getRowsWithEvents(dailyActiveTab));
+
+    return eventRows;
+}
+
+/**
  * Fetches all of the tabs of the active spreadsheet
  *
  * @returns an array of spreadsheet tabs

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,9 +1,10 @@
 import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 
-const TODOLISTS_PATH = '/todolists/';
-const TODO_PATH = '/todos/';
-const JSON_PATH = '.json';
-const TODO_JSON_PATH = '/todos' + JSON_PATH;
+const TODOLISTS_PATH: string = '/todolists/';
+const TODO_PATH: string = '/todos/';
+const JSON_PATH: string = '.json';
+const TODO_JSON_PATH: string = '/todos' + JSON_PATH;
+export const TODOLIST_ID: string= "7865336721";
 
 /**
  * Creates a todo in Basecamp

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -31,8 +31,8 @@ declare interface Row {
 }
 
 declare interface RowBasecampMapping {
-  rowHash: string
-  // Other properties such as the Basecamp Todo id can be added here
+  rowHash: string,
+  basecampTodoIds: string[]
 }
 
 type HTTPResponse = GoogleAppsScript.URL_Fetch.HTTPResponse;


### PR DESCRIPTION
## Description
Core logic for creating new Todos
<img width="623" alt="Screenshot 2024-10-01 at 2 52 55 PM" src="https://github.com/user-attachments/assets/d281b6f0-3659-4ff4-9a14-f7ba924a1529">

## Changes Included in this PR
* Added missing type declarations (previously missed)
* Fixed a bug where the `hasId()` check for a row was always true
* Core logic for scanning through the Onestop and sending requests to Basecamp to create Todos for event rows
* Utility function to clear all row metadata/document properties (this is useful while debugging and can be triggered manually to "start fresh")
* Updated the row basecamp mapping to include the Todo ids
* Removed the batched `saveRows()` function as we will be looping
* Small refactoring to abstract away more of the event row fetching and basecamp request fetching away from the core logic