### PR TITLE
fix people parsing and skip unprocessed rows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,7 +23,10 @@ export function importOnestopToBasecamp(): void {
             processNewRow(eventRow);
         }
 
-        processedRowIds.push(getId(eventRow));
+        // Some rows may not have an id if a todo request isn't successfully made
+        if (hasId(eventRow)) {
+            processedRowIds.push(getId(eventRow));
+        }
     }
 
     deleteOldRows(processedRowIds);

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -243,9 +243,9 @@ export function getBasecampTodoForLeads(row: Row): BasecampTodoRequest | undefin
 
     if(leadIds.length > 0) {
         return getBasecampTodoRequest(basecampTodoContent, basecampTodoDescription, leadIds, leadIds, 
-            true, basecampDueDate);
+            false, basecampDueDate);
     } else {
-        Logger.log(`${getLeadsNames(row)} do not have any Basecamp ids`);
+        Logger.log(`${getLeadsNames(row)} do not have any Basecamp ids. row: ${row}`);
         
         return undefined;
     }
@@ -334,14 +334,14 @@ export function getBasecampTodosForHelpers(row: Row): BasecampTodoRequest[] {
         const basecampTodoContent: string = `${roleTitle}: ${row.what.value}`;
         const basecampTodoDescription: string = getBasecampTodoDescription(row);
         const helperIds: string[] = helperGroup.helperIds.filter(id => !leadIds.includes(id));
-        const asssigneeIds: string[] = leadIds.concat(helperIds);
+        const assigneeIds: string[] = leadIds.concat(helperIds);
         const basecampDueDate: string = getBasecampDueDate(row);
 
-        if(asssigneeIds.length > 0) {
+        if(assigneeIds.length > 0) {
             basecampTodoRequests.push(getBasecampTodoRequest(basecampTodoContent, basecampTodoDescription, 
-                asssigneeIds, asssigneeIds, true, basecampDueDate));
+                assigneeIds, leadIds, false, basecampDueDate));
         } else {
-            Logger.log(`${row.helpers.value} do not have any Basecamp ids`);
+            Logger.log(`${row.helpers.value} do not have any Basecamp ids. row: ${row}`);
         }
     }
 


### PR DESCRIPTION
This fixes:
* the people db loading to correctly extract out only the first and last name, and skipping the middle name and city in parenthesis. before, it was somehow including the city in parenthesis still and i couldn't fix the regex. 
* normalizes the person name before searching the db. if i enter in a cell `@Andrew Chan (Sd)`, it wouldn't find it in the db
* if rows are skipped from the lead name not being recognized, it won't try to take an id from it, as it won't be saved