### PR TITLE
Dev/core logic update existing todos

### DIFF
--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -68,6 +68,18 @@ export function sendBasecampPutRequest(requestUrl: string, requestPayload: JsonO
     return JSON.parse(response.getContentText());
 }
 
+export function sendBasecampDeleteRequest(requestUrl: string): void {
+    const response: HTTPResponse = UrlFetchApp.fetch(requestUrl, {
+        method: HTTP_PUT_METHOD,
+        headers: getHeaders()
+    });
+
+    // Check if the response is ok (status code in the range 200-299)
+    if (response.getResponseCode() != 204) {
+        throw new Error(`HTTP error! Status: ${response.getResponseCode()}`);
+    }
+}
+
 /**
  * Performs a GET request for a Basecamp API, with built in pagination if applicable
  * 

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -65,7 +65,14 @@ export function sendBasecampPutRequest(requestUrl: string, requestPayload: JsonO
         headers: getHeaders(),
         payload: JSON.stringify(requestPayload)
     });
-    return JSON.parse(response.getContentText());
+
+    const contentText = response.getContentText();
+
+    if (contentText) {
+        return JSON.parse(contentText);
+    } else {
+        return {};
+    }
 }
 
 /**

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -66,7 +66,7 @@ export function sendBasecampPutRequest(requestUrl: string, requestPayload: JsonO
         payload: JSON.stringify(requestPayload)
     });
 
-    const contentText = response.getContentText();
+    const contentText: string = response.getContentText();
 
     if (contentText) {
         return JSON.parse(contentText);

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -68,18 +68,6 @@ export function sendBasecampPutRequest(requestUrl: string, requestPayload: JsonO
     return JSON.parse(response.getContentText());
 }
 
-export function sendBasecampDeleteRequest(requestUrl: string): void {
-    const response: HTTPResponse = UrlFetchApp.fetch(requestUrl, {
-        method: HTTP_PUT_METHOD,
-        headers: getHeaders()
-    });
-
-    // Check if the response is ok (status code in the range 200-299)
-    if (response.getResponseCode() != 204) {
-        throw new Error(`HTTP error! Status: ${response.getResponseCode()}`);
-    }
-}
-
 /**
  * Performs a GET request for a Basecamp API, with built in pagination if applicable
  * 

--- a/src/main/error/basecampRequestMissingError.ts
+++ b/src/main/error/basecampRequestMissingError.ts
@@ -1,0 +1,9 @@
+export class BasecampRequestMissingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TodoIsMissingError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, BasecampRequestMissingError.prototype);
+    }
+}

--- a/src/main/error/rowBasecampMappingMissingError.ts
+++ b/src/main/error/rowBasecampMappingMissingError.ts
@@ -1,0 +1,9 @@
+export class RowBasecampMappingMissingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "RowBasecampMappingMissingError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, RowBasecampMappingMissingError.prototype);
+    }
+}

--- a/src/main/error/todoIdMissingError.ts
+++ b/src/main/error/todoIdMissingError.ts
@@ -1,0 +1,9 @@
+export class TodoIsMissingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TodoIsMissingError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, TodoIsMissingError.prototype);
+    }
+}

--- a/src/main/error/todoIdMissingError.ts
+++ b/src/main/error/todoIdMissingError.ts
@@ -1,9 +1,9 @@
-export class TodoIsMissingError extends Error {
+export class TodoIdMissingError extends Error {
     constructor(message: string) {
         super(message);
-        this.name = "TodoIsMissingError";
+        this.name = "TodoIdMissingError";
 
         // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
-        Object.setPrototypeOf(this, TodoIsMissingError.prototype);
+        Object.setPrototypeOf(this, TodoIdMissingError.prototype);
     }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,12 +47,12 @@ function processExistingRow(row: Row): void {
     if(hasChanged(row)) {
 
         const currentRoleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
-        const currentRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
+        const lastSavedRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
 
-        deleteObsoleteTodos(currentRoleRequestMap, currentRoleTodoIdMap);
+        deleteObsoleteTodos(currentRoleRequestMap, lastSavedRoleTodoIdMap);
 
-        const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(currentRoleRequestMap, currentRoleTodoIdMap);
-        const existingRoleTodoIdMap: RoleTodoIdMap = updateTodosForExistingRoles(currentRoleRequestMap, currentRoleTodoIdMap)
+        const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
+        const existingRoleTodoIdMap: RoleTodoIdMap = updateTodosForExistingRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
 
         const updatedRoleTodoIdMap: RoleTodoIdMap = {...existingRoleTodoIdMap, ...newRoleTodoIdMap};
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -54,9 +54,10 @@ function processExistingRow(row: Row): void {
         
         updateTodos(basecampTodoRequests, roleTodoIdMap)
 
-        deleteObsoleteTodos(basecampTodoRequests, roleTodoIdMap);
+        const obsoleteRoles = deleteObsoleteTodos(basecampTodoRequests, roleTodoIdMap);
+        const newRoleIdTodoIdMap = deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles, roleTodoIdMap)
 
-        saveRow(row, roleTodoIdMap);
+        saveRow(row, newRoleIdTodoIdMap);
     }
 }
 
@@ -118,8 +119,9 @@ function getRoleTodoIdMap(row: Row) {
  * 
  * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
  * @param roleTodoIdMap a map associating an event's roles with todo ids
+ * @returns a string array of obsolete roles that were deleted
  */
-function deleteObsoleteTodos(basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: { [key: string]: string }): void {
+function deleteObsoleteTodos(basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: { [key: string]: string }): string[] {
 
     Logger.log("Checking for obsolete roles...\n")
 
@@ -137,9 +139,25 @@ function deleteObsoleteTodos(basecampTodoRequests: Map<string, BasecampTodoReque
         }
 
         deleteTodo(todoIdentifier);
+    }
 
+    return obsoleteRoles;
+}
+
+/**
+ * Modifies the roleTodoIdMap by removing obsolete roles.
+ * 
+ * @param obsoleteRoles a string array of obsolete roles no longer needed for an event
+ * @param roleTodoIdMap a map associating an event's roles with todo ids
+ * @returns the updated roleTodoIdMap without the obsolete roles
+ */
+function deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles: string[], roleTodoIdMap: { [key: string]: string }):  { [key: string]: string } {
+
+    for(const role of obsoleteRoles) {
         delete roleTodoIdMap[role]; // Modify the roleTodoIdMap to reflect changes in the document properties
     }
+
+    return roleTodoIdMap
 }
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,14 +1,7 @@
-import { PROJECT_ID } from "./basecamp";
-import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
-import { getRoleTodoIdMap } from "./role";
-import { generateIdForRow, getBasecampTodoRequestsForRow, getId, getRowBasecampMapping, hasChanged, hasId, saveRow } from "./row";
+import { getRoleTodoIdMap } from "./row";
+import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
 import { getEventRowsFromSpreadsheet } from "./scan";
-import { createNewTodos, createTodo, createTodosForNewRoles, deleteObsoleteTodos, deleteTodo, deleteTodos, TODOLIST_ID, updateTodo, updateTodosForSurvivingRoles } from "./todos";
-
-export const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
-    projectId: PROJECT_ID,
-    todolistId: TODOLIST_ID
-};
+import { createNewTodos, createTodosForNewRoles, deleteObsoleteTodos, updateTodosForExistingRoles } from "./todos";
 
 /**
  * Main entry point for the Onestop to Basecamp Integration that contains the core logic for
@@ -59,9 +52,9 @@ function processExistingRow(row: Row): void {
         deleteObsoleteTodos(currentRoleRequestMap, currentRoleTodoIdMap);
 
         const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(currentRoleRequestMap, currentRoleTodoIdMap);
-        const survivingRoleTodoIdMap: RoleTodoIdMap = updateTodosForSurvivingRoles(currentRoleRequestMap, currentRoleTodoIdMap)
+        const existingRoleTodoIdMap: RoleTodoIdMap = updateTodosForExistingRoles(currentRoleRequestMap, currentRoleTodoIdMap)
 
-        const updatedRoleTodoIdMap: RoleTodoIdMap = {...survivingRoleTodoIdMap, ...newRoleTodoIdMap};
+        const updatedRoleTodoIdMap: RoleTodoIdMap = {...existingRoleTodoIdMap, ...newRoleTodoIdMap};
 
         saveRow(row, updatedRoleTodoIdMap);
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,8 +23,10 @@ export function importOnestopToBasecamp(): void {
 
     for(const eventRow of eventRows) {
         if(hasId(eventRow)) {
+            console.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} already exists! Processing as exiting row...\n`);
             processExistingRow(eventRow);
         } else {
+            console.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} is new! Processing as a new row...\n`)
             processNewRow(eventRow);
         }
 
@@ -45,8 +47,11 @@ export function importOnestopToBasecamp(): void {
  */
 function processExistingRow(row: Row): void {
 
+    Logger.log("Checking if the row has changed...\n")
+
     if(hasChanged(row)) {
 
+        Logger.log("Changes detected in row! Updateding associated todos to reflect changes...\n")
         const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
 
         const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
@@ -62,18 +67,20 @@ function processExistingRow(row: Row): void {
                 throw new BasecampRequestMissingError("Missing basecamp request!");
                 
             } else if (todoId == undefined) {
+                Logger.log(`Todo Id is undefined in the roleRodoIdMap! Creating new todo for ${row.what.value}...\n`)
                 createTodo(request, DEFAULT_TODOLIST_IDENTIFIER)
-
+                
             } else {
-
+                
                 let todoIdentifier: TodoIdentifier = {
                     projectId: PROJECT_ID,
                     todoId: todoId
                 }
-
+                
+                Logger.log(`Updating todo for ${row.what.value} (${row.startTime.getDate()})...\n`)
                 updateTodo(request, todoIdentifier)
             }
-        }
+        }   
 
         const newRoles = Array.from(basecampTodoRequests.keys());
         const oldRoles: string[] = roles.filter(role => !newRoles.includes(role));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,10 +23,10 @@ export function importOnestopToBasecamp(): void {
 
     for(const eventRow of eventRows) {
         if(hasId(eventRow)) {
-            console.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} already exists! Processing it as an existing row...\n`);
+            Logger.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} already exists! Processing it as an existing row...\n`);
             processExistingRow(eventRow);
         } else {
-            console.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} is new! Processing it as a new row...\n`)
+            Logger.log(`Row for ${eventRow.what.value} on ${eventRow.startTime} is new! Processing it as a new row...\n`)
             processNewRow(eventRow);
         }
 
@@ -50,13 +50,13 @@ function processExistingRow(row: Row): void {
     if(hasChanged(row)) {
 
         const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
-        const existingRoleTodoIdMap: { [key: string]: string }  = getRoleTodoIdMap(row);
+        const existingRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
         
         const currentRoles: string[] = getCurrentEventRoles(basecampTodoRequests);
         const originalRoles: string[] = getOriginalEventRoles(existingRoleTodoIdMap);
 
         const newRoles: string[] = getNewRoles(currentRoles, originalRoles);
-        const newRoleTodoIdMap: { [key: string]: string } = createTodosForNewRoles(newRoles, basecampTodoRequests);
+        const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(newRoles, basecampTodoRequests);
 
         const existingRoles: string[] = getExistingRoles(currentRoles, originalRoles);
         updateTodosForExistingRoles(existingRoles, basecampTodoRequests, existingRoleTodoIdMap)
@@ -75,7 +75,7 @@ function processExistingRow(row: Row): void {
  * 
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  */
-function getOriginalEventRoles(roleTodoIdMap: { [key: string]: string }): string[] {
+function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
     return Object.keys(roleTodoIdMap);
 }
 
@@ -96,7 +96,7 @@ function getCurrentEventRoles(basecampTodoRequests: Map<string, BasecampTodoRequ
  * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  */
-function updateTodosForExisting(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: { [key: string]: string }) {
+function updateTodosForExisting(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: RoleTodoIdMap) {
     Logger.log("Changes detected in a row! Updateding associated todos to reflect changes...\n");
     updateTodosForExistingRoles(existingRoles, basecampTodoRequests, roleTodoIdMap);
 }
@@ -130,9 +130,9 @@ function getExistingRoles(currentRoles: string[], originalRoles: string[]): stri
  * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
  * @returns an object mapping new roles with their newly created todo ids
  */
-function createTodosForNewRoles(newRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>): { [key: string]: string } {
+function createTodosForNewRoles(newRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>): RoleTodoIdMap {
 
-    const newRoleTodoIdMap: { [key: string]: string } = {};
+    const newRoleTodoIdMap: RoleTodoIdMap = {};
 
     for(const role in newRoles) {
         let request = basecampTodoRequests.get(role);
@@ -151,7 +151,7 @@ function createTodosForNewRoles(newRoles: string[], basecampTodoRequests: Map<st
  * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
  * @param roleTodoIdMap a map associating an event's roles with existing todo ids
  */
-function updateTodosForExistingRoles(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: { [key: string]: string }) {
+function updateTodosForExistingRoles(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: RoleTodoIdMap) {
 
     for(const role in existingRoles) {
         let existingTodoId = roleTodoIdMap[role];
@@ -189,7 +189,7 @@ function getRoleTodoIdMap(row: Row) {
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  * @returns a string array of obsolete roles that were deleted
  */
-function deleteObsoleteTodos(obsoleteRoles: string[], roleTodoIdMap: { [key: string]: string }): string[] {
+function deleteObsoleteTodos(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
     Logger.log("Checking for obsolete roles...\n")
     const obsoleteTodoIds: string[] = getObsoleteTodosIds(obsoleteRoles, roleTodoIdMap);
     deleteTodos(obsoleteTodoIds);
@@ -214,7 +214,7 @@ function getObsoleteRoles(currentRoles: string[], originalRoles: string[]) {
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  * @returns an array of obsolete roles
  */
-function getObsoleteTodosIds(obsoleteRoles: string[], roleTodoIdMap: { [key: string]: string }): string[] {
+function getObsoleteTodosIds(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
 
     const obsoleteTodoIds = []
     
@@ -253,7 +253,7 @@ function deleteTodos(todoIds: string[]): void {
  * @param existingRoleTodoIdMap the existing roleTodoIdMap that was fetched at the start of processing the existing row.
  * @returns the updated roleTodoIdMap without the obsolete roles/todos and with the newly added roles and todo ids
  */
-function updateRoleTodoIdMap( obsoleteRoles: string[], newRoleIdTodoIdMap: { [key: string]: string }, existingRoleTodoIdMap: { [key: string]: string }): { [key: string]: string } {
+function updateRoleTodoIdMap( obsoleteRoles: string[], newRoleIdTodoIdMap: RoleTodoIdMap, existingRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
     let updatedRoleTodoIdMap = addNewRolesToRoleTodoIdMap(newRoleIdTodoIdMap, existingRoleTodoIdMap);
     updatedRoleTodoIdMap = deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles, updatedRoleTodoIdMap);
     return updatedRoleTodoIdMap;
@@ -266,7 +266,7 @@ function updateRoleTodoIdMap( obsoleteRoles: string[], newRoleIdTodoIdMap: { [ke
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  * @returns the updated roleTodoIdMap without the obsolete roles
  */
-function deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles: string[], roleTodoIdMap: { [key: string]: string }):  { [key: string]: string } {
+function deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap):  RoleTodoIdMap {
 
     for(const role of obsoleteRoles) {
         delete roleTodoIdMap[role]; // Modify the roleTodoIdMap to reflect changes in the document properties
@@ -282,7 +282,7 @@ function deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles: string[], roleTodoI
  * @param newRoleTodoIdMap a generated map that represents new roles associated with newly created todo ids
  * @param roleTodoIdMap a map retrieved from the document properties associating an event's existing roles with existing todo ids
  */
-function addNewRolesToRoleTodoIdMap(newRoleTodoIdMap: { [key: string]: string }, existingRoleTodoIdMap: { [key: string]: string }): { [key: string]: string } {
+function addNewRolesToRoleTodoIdMap(newRoleTodoIdMap: RoleTodoIdMap, existingRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
     return { ...newRoleTodoIdMap, ...existingRoleTodoIdMap };
 }
 
@@ -295,7 +295,7 @@ function addNewRolesToRoleTodoIdMap(newRoleTodoIdMap: { [key: string]: string },
  */
 function processNewRow(row: Row): void {
     const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
-    const roleTodoIdMap: { [key: string]: string } = createNewTodos(basecampTodoRequests);
+    const roleTodoIdMap: RoleTodoIdMap = createNewTodos(basecampTodoRequests);
 
     if(Object.keys(roleTodoIdMap).length > 0) {
         generateIdForRow(row);
@@ -309,8 +309,8 @@ function processNewRow(row: Row): void {
  * @param basecampRequests array of BasecampTodoRequest objects to send
  * @returns a map that associates role titles with basecamp todo ids
  */
-function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): { [key: string]: string } {
-    const roleTodoIdMap: { [key: string]: string } = {};
+function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): RoleTodoIdMap {
+    const roleTodoIdMap: RoleTodoIdMap = {};
 
     for (const [roleTitle, basecampRequest] of basecampRequests) {
         let basecampTodoId: string = createTodo(basecampRequest, DEFAULT_TODOLIST_IDENTIFIER)

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,12 +1,11 @@
 import { PROJECT_ID } from "./basecamp";
-import { BasecampRequestMissingError } from "./error/basecampRequestMissingError";
 import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
-import { TodoIsMissingError } from "./error/todoIdMissingError";
+import { getRoleTodoIdMap } from "./role";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, getRowBasecampMapping, hasChanged, hasId, saveRow } from "./row";
 import { getEventRowsFromSpreadsheet } from "./scan";
-import { createTodo, deleteTodo, TODOLIST_ID, updateTodo } from "./todos";
+import { createNewTodos, createTodo, createTodosForNewRoles, deleteObsoleteTodos, deleteTodo, deleteTodos, TODOLIST_ID, updateTodo, updateTodosForSurvivingRoles } from "./todos";
 
-const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
+export const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
     projectId: PROJECT_ID,
     todolistId: TODOLIST_ID
 };
@@ -43,247 +42,29 @@ export function importOnestopToBasecamp(): void {
  * Processes existing event rows by checking whether the row has been modified and if so indiscriminately
  * updates all the tasks in basecamp with the new information while updating backend metadata
  * 
+ * If new helper groups are added new tasks in basecamp are created for them
+ * If helper groups are deleted then their corresponding tasks in basecamp will also be deleted.
+ * 
+ * The current state of the row will always be saved into the document properties at the end.
+ * 
  * @param row 
  */
 function processExistingRow(row: Row): void {
 
     if(hasChanged(row)) {
 
-        const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
-        const existingRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
-        
-        const currentRoles: string[] = getCurrentEventRoles(basecampTodoRequests);
-        const originalRoles: string[] = getOriginalEventRoles(existingRoleTodoIdMap);
+        const currentRoleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
+        const currentRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
 
-        const newRoles: string[] = getNewRoles(currentRoles, originalRoles);
-        const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(newRoles, basecampTodoRequests);
+        deleteObsoleteTodos(currentRoleRequestMap, currentRoleTodoIdMap);
 
-        const existingRoles: string[] = getExistingRoles(currentRoles, originalRoles);
-        updateTodosForExistingRoles(existingRoles, basecampTodoRequests, existingRoleTodoIdMap)
+        const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(currentRoleRequestMap, currentRoleTodoIdMap);
+        const survivingRoleTodoIdMap: RoleTodoIdMap = updateTodosForSurvivingRoles(currentRoleRequestMap, currentRoleTodoIdMap)
 
-        const obsoleteRoles: string[] = getObsoleteRoles(currentRoles, originalRoles);
-        deleteObsoleteTodos(obsoleteRoles, existingRoleTodoIdMap);
+        const updatedRoleTodoIdMap: RoleTodoIdMap = {...survivingRoleTodoIdMap, ...newRoleTodoIdMap};
 
-        const newRoleIdTodoIdMap = updateRoleTodoIdMap(obsoleteRoles, newRoleTodoIdMap, existingRoleTodoIdMap)
-
-        saveRow(row, newRoleIdTodoIdMap);
+        saveRow(row, updatedRoleTodoIdMap);
     }
-}
-
-/**
- * Gets a list of roles from a roleTodoIdMap
- * 
- * @param roleTodoIdMap a map associating an event's roles with todo ids
- */
-function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
-    return Object.keys(roleTodoIdMap);
-}
-
-/**
- * Gets a list of roles from a basecampTodoRequests map
-
- * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
- */
-function getCurrentEventRoles(basecampTodoRequests: Map<string, BasecampTodoRequest>): string[] {
-    return Array.from(basecampTodoRequests.keys());
-}
-
-/**
- * Updates todos in basecamp for existing roles. Otherwise create a new todos for new roles
- * 
- * @param currentRoles a string array of current event roles
- * @param originalRoles a string array of original event roles
- * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
- * @param roleTodoIdMap a map associating an event's roles with todo ids
- */
-function updateTodosForExisting(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: RoleTodoIdMap) {
-    Logger.log("Changes detected in a row! Updateding associated todos to reflect changes...\n");
-    updateTodosForExistingRoles(existingRoles, basecampTodoRequests, roleTodoIdMap);
-}
-
-/**
- * Gets a list of new roles by comparing the original and current roles together
- * 
- * @param currentRoles a string array of current event roles
- * @param originalRoles a string array of original event roles
- * @returns an array of obsolete roles
- */
-function getNewRoles(currentRoles: string[], originalRoles: string[]): string[] {
-    return currentRoles.filter(role => !originalRoles.includes(role));
-}
-
-/**
- * Gets a list of roles that haven't changed by comparing the original and current roles together
- * 
- * @param currentRoles a string array of current event roles
- * @param originalRoles a string array of original event roles
- * @returns an array of obsolete roles
- */
-function getExistingRoles(currentRoles: string[], originalRoles: string[]): string[] {
-    return currentRoles.filter(role => originalRoles.includes(role));
-}
-
-/**
- * Create todos for new roles. Gets the request body from the basecampTodoRequests map
- * 
- * @param newRoles a string array of current event roles
- * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
- * @returns an object mapping new roles with their newly created todo ids
- */
-function createTodosForNewRoles(newRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>): RoleTodoIdMap {
-
-    const newRoleTodoIdMap: RoleTodoIdMap = {};
-
-    for(const role in newRoles) {
-        let request = basecampTodoRequests.get(role);
-        let newTodoId = createTodo(request, DEFAULT_TODOLIST_IDENTIFIER);
-        newRoleTodoIdMap[role] = newTodoId;
-    }
-
-    return newRoleTodoIdMap;
-}
-
-/**
- * Updates todos for existing roles. Gets the request body from the basecampTodoRequests map
- * Gets the existing todo id from the roleTodoIdMap object
- * 
- * @param newRoles a string array of current event roles
- * @param basecampTodoRequests a map associating role titles with BasecampTodoRequest objects
- * @param roleTodoIdMap a map associating an event's roles with existing todo ids
- */
-function updateTodosForExistingRoles(existingRoles: string[], basecampTodoRequests: Map<string, BasecampTodoRequest>, roleTodoIdMap: RoleTodoIdMap) {
-
-    for(const role in existingRoles) {
-        let existingTodoId = roleTodoIdMap[role];
-        let request = basecampTodoRequests.get(role);
-
-        let todoIdentifier: TodoIdentifier = {
-            projectId: PROJECT_ID,
-            todoId: existingTodoId
-        }
-
-        updateTodo(request, todoIdentifier)
-    }
-}
-
-/**
- * Gets the roleTodoIdMap object from the RowBasecampMapping object.
- * Used for downstream processing
- * 
- * @param row a list of all the current roles associated with the row including the lead role. This may be identical to the original roles
- * @returns a map that associates role titles with basecamp todo ids
- */
-function getRoleTodoIdMap(row: Row) {
-    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
-    if(savedRowBasecampMapping == null) {
-        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null! Unable to proceed with updating the todo!");
-    }
-    return savedRowBasecampMapping.roleTodoIdMap
-}
-
-/**
- * Deletes todos associated with helper groups that are no longer present on the event row.
- * The first line checks whether there are any rows present in the original roles that are not present in the current roles (indicating an obsolete role)
- * 
- * @param obsoleteRoles an array of all the roles no longer associated with the event
- * @param roleTodoIdMap a map associating an event's roles with todo ids
- * @returns a string array of obsolete roles that were deleted
- */
-function deleteObsoleteTodos(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
-    Logger.log("Checking for obsolete roles...\n")
-    const obsoleteTodoIds: string[] = getObsoleteTodosIds(obsoleteRoles, roleTodoIdMap);
-    deleteTodos(obsoleteTodoIds);
-    return obsoleteRoles;
-}
-
-/**
- * Gets a list of obsolete roles by comparing the original and current roles together
- * 
- * @param originalRoles a string array of original event roles
- * @param currentRoles a string array of current event roles
- * @returns an array of obsolete roles
- */
-function getObsoleteRoles(currentRoles: string[], originalRoles: string[]) {
-    return originalRoles.filter(role => !currentRoles.includes(role));
-}
-
-/**
- * Gets a list of obsolete todo ids based off of the obsolete roels roles by comparing the original and current roles together
- * 
- * @param obsoleteRoles an array of obsolete roles
- * @param roleTodoIdMap a map associating an event's roles with todo ids
- * @returns an array of obsolete roles
- */
-function getObsoleteTodosIds(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
-
-    const obsoleteTodoIds = []
-    
-    for(const role of obsoleteRoles) {
-        Logger.log(`Found obsolete role: ${role}!\n`)
-        let todoId = roleTodoIdMap[role];
-        obsoleteTodoIds.push(todoId);
-    }
-
-    return obsoleteTodoIds
-}
-
-/**
- * Deletes the list of todos based on their todo ids
- * 
- * @param todoIds todo ids corresponding to todos to delete
- */
-function deleteTodos(todoIds: string[]): void {
-
-    for(const id of todoIds) {
-
-        let todoIdentifier: TodoIdentifier = {
-            projectId: PROJECT_ID,
-            todoId: id
-        }
-
-        deleteTodo(todoIdentifier);
-    }
-}
-
-/**
- * Updates the existing roleTodoIdMap to include new roles/ids and deletes obsolete roles/ids
- * 
- * @param obsoleteRoles a string array of obsolete roles no longer needed for an event
- * @param newRoleIdTodoIdMap a map associating an event's new roles with new todo ids
- * @param existingRoleTodoIdMap the existing roleTodoIdMap that was fetched at the start of processing the existing row.
- * @returns the updated roleTodoIdMap without the obsolete roles/todos and with the newly added roles and todo ids
- */
-function updateRoleTodoIdMap( obsoleteRoles: string[], newRoleIdTodoIdMap: RoleTodoIdMap, existingRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
-    let updatedRoleTodoIdMap = addNewRolesToRoleTodoIdMap(newRoleIdTodoIdMap, existingRoleTodoIdMap);
-    updatedRoleTodoIdMap = deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles, updatedRoleTodoIdMap);
-    return updatedRoleTodoIdMap;
-}
-
-/**
- * Modifies the roleTodoIdMap by removing obsolete roles.
- * 
- * @param obsoleteRoles a string array of obsolete roles no longer needed for an event
- * @param roleTodoIdMap a map associating an event's roles with todo ids
- * @returns the updated roleTodoIdMap without the obsolete roles
- */
-function deleteObsoleteRolesFromRoleTodoIdMap(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap):  RoleTodoIdMap {
-
-    for(const role of obsoleteRoles) {
-        delete roleTodoIdMap[role]; // Modify the roleTodoIdMap to reflect changes in the document properties
-    }
-
-    return roleTodoIdMap
-}
-
-/**
- * Combines the existing roleTodoIdMap with a new roleTodoIdMap object in order to avoid keep the document properties
- * consistent with the state of the onestop
- * 
- * @param newRoleTodoIdMap a generated map that represents new roles associated with newly created todo ids
- * @param roleTodoIdMap a map retrieved from the document properties associating an event's existing roles with existing todo ids
- */
-function addNewRolesToRoleTodoIdMap(newRoleTodoIdMap: RoleTodoIdMap, existingRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
-    return { ...newRoleTodoIdMap, ...existingRoleTodoIdMap };
 }
 
 /**
@@ -294,30 +75,13 @@ function addNewRolesToRoleTodoIdMap(newRoleTodoIdMap: RoleTodoIdMap, existingRol
  * @param row 
  */
 function processNewRow(row: Row): void {
-    const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
-    const roleTodoIdMap: RoleTodoIdMap = createNewTodos(basecampTodoRequests);
+    const roleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
+    const roleTodoIdMap: RoleTodoIdMap = createNewTodos(roleRequestMap);
 
     if(Object.keys(roleTodoIdMap).length > 0) {
         generateIdForRow(row);
         saveRow(row, roleTodoIdMap);
     }
-}
-
-/**
- * Sends requests to create new Basecamp Todos
- * 
- * @param basecampRequests array of BasecampTodoRequest objects to send
- * @returns a map that associates role titles with basecamp todo ids
- */
-function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): RoleTodoIdMap {
-    const roleTodoIdMap: RoleTodoIdMap = {};
-
-    for (const [roleTitle, basecampRequest] of basecampRequests) {
-        let basecampTodoId: string = createTodo(basecampRequest, DEFAULT_TODOLIST_IDENTIFIER)
-        roleTodoIdMap[roleTitle] = basecampTodoId;
-    }
-
-    return roleTodoIdMap;
 }
 
 function deleteOldRows(processedRowIds: string[]): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,12 +46,12 @@ function processExistingRow(row: Row): void {
  * @param row 
  */
 function processNewRow(row: Row): void {
-    const basecampTodoRequests: BasecampTodoRequest[] = getBasecampTodoRequestsForRow(row);
-    const basecampTodoIds: string[] = createNewTodos(basecampTodoRequests);
+    const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
+    const roleTodoIdMap: Map<string, string> = createNewTodos(basecampTodoRequests);
 
-    if(basecampTodoIds.length > 0) {
+    if(roleTodoIdMap.size > 0) {
         generateIdForRow(row);
-        saveRow(row, basecampTodoIds);
+        saveRow(row, roleTodoIdMap);
     }
 }
 
@@ -59,12 +59,14 @@ function processNewRow(row: Row): void {
  * Sends requests to create new Basecamp Todos
  * 
  * @param basecampRequests array of BasecampTodoRequest objects to send
- * @returns array of corresponding Basecamp Todo ids
+ * @returns a map that associates role titles with basecamp todo ids
  */
-function createNewTodos(basecampRequests: BasecampTodoRequest[]): string[] {
-    const basecampTodoIds: string[] = [];
-    for(const request of basecampRequests) {
-        basecampTodoIds.push(createTodo(request, DEFAULT_TODOLIST_IDENTIFIER));
+function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): Map<string, string> {
+    const basecampTodoIds = new Map<string, string>();
+
+    for (const [roleTitle, basecampRequest] of basecampRequests) {
+        let basecampTodoId: string = createTodo(basecampRequest, DEFAULT_TODOLIST_IDENTIFIER)
+        basecampTodoIds.set(roleTitle, basecampTodoId);
     }
 
     return basecampTodoIds;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -55,7 +55,7 @@ function processExistingRow(row: Row): void {
 
         for (const role of roles) {
 
-            let todoId = savedRowBasecampMapping?.roleTodoIdMap.get(role);
+            let todoId = savedRowBasecampMapping?.roleTodoIdMap[role];
             let request = basecampTodoRequests.get(role);
 
             if(request == undefined) {
@@ -93,9 +93,9 @@ function processExistingRow(row: Row): void {
  */
 function processNewRow(row: Row): void {
     const basecampTodoRequests: Map<string, BasecampTodoRequest> = getBasecampTodoRequestsForRow(row);
-    const roleTodoIdMap: Map<string, string> = createNewTodos(basecampTodoRequests);
+    const roleTodoIdMap: { [key: string]: string } = createNewTodos(basecampTodoRequests);
 
-    if(roleTodoIdMap.size > 0) {
+    if(Object.keys(roleTodoIdMap).length > 0) {
         generateIdForRow(row);
         saveRow(row, roleTodoIdMap);
     }
@@ -107,12 +107,12 @@ function processNewRow(row: Row): void {
  * @param basecampRequests array of BasecampTodoRequest objects to send
  * @returns a map that associates role titles with basecamp todo ids
  */
-function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): Map<string, string> {
-    const basecampTodoIds = new Map<string, string>();
+function createNewTodos(basecampRequests: Map<string, BasecampTodoRequest>): { [key: string]: string } {
+    const basecampTodoIds: { [key: string]: string } = {};
 
     for (const [roleTitle, basecampRequest] of basecampRequests) {
         let basecampTodoId: string = createTodo(basecampRequest, DEFAULT_TODOLIST_IDENTIFIER)
-        basecampTodoIds.set(roleTitle, basecampTodoId);
+        basecampTodoIds[roleTitle] = basecampTodoId;
     }
 
     return basecampTodoIds;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,7 +6,7 @@
  */
 
 export const onOpen = (e: OpenEvent) => {
-  console.log("Updating OneStop menu...")
+  Logger.log("Updating OneStop menu...")
   const tabSyncMenu: GoogleAppsScript.Base.Menu = SpreadsheetApp.getUi()
     .createMenu('Basecamp')
     .addItem('Assign Basecamp Tasks', 'importOnestopToBasecamp')

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -25,6 +25,7 @@ export function getDocumentProperty(key: string): string | null {
     return value;
 }
 
+
 /**
  * Sets a document property in the PropertiesService
  * 
@@ -111,4 +112,24 @@ export function deleteAllDocumentProperties(): void {
         const error: Error = e as Error;
         throw new PropertiesServiceDeleteError(`Failed to delete all document properties: ${error.message}`)
     }
+}
+
+/**
+ * Logs all document properties of the current Google Sheets document.
+ *
+ * Retrieves and logs key-value pairs from the document properties using the 
+ * Apps Script Logger. Useful for debugging and auditing document metadata.
+ *
+ * @function logDocumentProperties
+ * @returns {void}
+ *
+ * @example
+ * logDocumentProperties();
+ */
+export function logDocumentProperties() {
+    var allProperties = documentProperties.getProperties();
+    for (var key in allProperties) {
+      Logger.log(key + ': ' + allProperties[key]);
+    }
+
 }

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -25,6 +25,21 @@ export function getDocumentProperty(key: string): string | null {
     return value;
 }
 
+/**
+ * Retrieves a document property from the PropertiesService
+ * 
+ * @returns the property or null if the key does not have a property
+ */
+export function getAllDocumentProperties(): DocumentProperties {
+    const allProperties: { [key: string]: string } = documentProperties.getProperties();
+    const propertyStore: DocumentProperties = {};
+
+    for (const key in allProperties) {
+        propertyStore[key] = JSON.parse(allProperties[key]);
+    }
+
+    return propertyStore;
+}
 
 /**
  * Sets a document property in the PropertiesService
@@ -104,6 +119,19 @@ export function setScriptProperties(properties: {[key: string]: string}): void {
 }
 
 /**
+ * Deletes a document property
+ * @param rowId the id for the row to be deleted from the document property store
+ */
+export function deleteDocumentProperty(rowId: string): void {
+    try {
+        documentProperties.deleteProperty(rowId);
+    } catch (e: any) {
+        const error: Error = e as Error;
+        throw new PropertiesServiceDeleteError(`Failed to delete all document property [${rowId}]: ${error.message}`)
+    }
+}
+
+/**
  * Useful debugging function that will clear all document properties
  */
 export function deleteAllDocumentProperties(): void {
@@ -128,7 +156,7 @@ export function deleteAllDocumentProperties(): void {
  * logDocumentProperties();
  */
 export function logDocumentProperties(): void {
-    const allProperties: DocumentProperties = documentProperties.getProperties();
+    const allProperties: {[key: string]: string} = documentProperties.getProperties();
     for (const key in allProperties) {
       Logger.log(key + ': ' + allProperties[key]);
     }

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -126,10 +126,9 @@ export function deleteAllDocumentProperties(): void {
  * @example
  * logDocumentProperties();
  */
-export function logDocumentProperties() {
-    var allProperties = documentProperties.getProperties();
-    for (var key in allProperties) {
+export function logDocumentProperties(): void {
+    const allProperties: DocumentProperties = documentProperties.getProperties();
+    for (const key in allProperties) {
       Logger.log(key + ': ' + allProperties[key]);
     }
-
 }

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -35,6 +35,7 @@ export function getDocumentProperty(key: string): string | null {
 export function setDocumentProperty(key: string, value: string): void {
     try {
         documentProperties.setProperty(key, value);
+        Logger.log(`New document property set:\n{${key}: ${value}}`)
     } catch (e: any) {
         const error: Error = e as Error;
         throw new PropertiesServiceWriteError(`Failed to save to document property PropertiesService: [key: ${key}, value: ${value}] ${error.message}`);

--- a/src/main/role.ts
+++ b/src/main/role.ts
@@ -1,9 +1,3 @@
-export enum RoleStatus {
-    REMOVED,
-    EXISTING,
-    NEW
-}
-
 /**
  * Gets a list of roles from a roleTodoIdMap
  * 
@@ -23,24 +17,40 @@ function getCurrentEventRoles(currentRoleRequestMap: RoleRequestMap): string[] {
 }
 
 /**
- * Gets a list of roles (i.e. obsolete, new, surviving) by comparing the original and current roles together
+ * Gets a list of obsolete roles by comparing the original and current roles
  * 
- * @param roleRequestMap a map associating an event's roles with api request bodies
- * @param currentRoleTodoIdMap a map associating an event's roles to existing todo ids, that is currently saved in the document properties
- * @returns an array of obsolete roles
+ * @param currentRoleRequestMap a map associating an event's roles with API request bodies
+ * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @returns an array of removed roles
  */
-export function getRoles(roleRequestMap: RoleRequestMap, currentRoleTodoIdMap: RoleTodoIdMap, roleStatus: RoleStatus): string[] {
-    const currentRoles: string[] = getCurrentEventRoles(roleRequestMap);
-    const originalRoles: string[] = getOriginalEventRoles(currentRoleTodoIdMap);
+export function getRemovedRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+    const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    return originalRoles.filter(role => !currentRoles.includes(role));
+}
 
-    switch(roleStatus) {
-        case RoleStatus.REMOVED:
-            return originalRoles.filter(role => !currentRoles.includes(role));
+/**
+ * Gets a list of existing roles by comparing the original and current roles
+ * 
+ * @param currentRoleRequestMap a map associating an event's roles with API request bodies
+ * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @returns an array of existing roles
+ */
+export function getExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+    const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    return currentRoles.filter(role => originalRoles.includes(role));
+}
 
-        case RoleStatus.EXISTING:
-            return currentRoles.filter(role => originalRoles.includes(role));
-        
-        case RoleStatus.NEW:
-            return currentRoles.filter(role => !originalRoles.includes(role));
-    }
+/**
+ * Gets a list of new roles by comparing the original and current roles
+ * 
+ * @param currentRoleRequestMap a map associating an event's roles with API request bodies
+ * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @returns an array of new roles
+ */
+export function getNewRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+    const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    return currentRoles.filter(role => !originalRoles.includes(role));
 }

--- a/src/main/role.ts
+++ b/src/main/role.ts
@@ -1,25 +1,7 @@
-import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
-import { getRowBasecampMapping } from "./row";
-
 export enum RoleStatus {
-    OBSOLETE,
-    SURVIVING,
+    REMOVED,
+    EXISTING,
     NEW
-}
-
-/**
- * Gets the roleTodoIdMap object from the RowBasecampMapping object.
- * Used for downstream processing
- * 
- * @param row a list of all the current roles associated with the row including the lead role. This may be identical to the original roles
- * @returns a map that associates role titles with basecamp todo ids
- */
-export function getRoleTodoIdMap(row: Row) {
-    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
-    if(savedRowBasecampMapping == null) {
-        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null! Unable to proceed with updating the todo!");
-    }
-    return savedRowBasecampMapping.roleTodoIdMap
 }
 
 /**
@@ -27,7 +9,7 @@ export function getRoleTodoIdMap(row: Row) {
  * 
  * @param roleTodoIdMap a map associating an event's roles with todo ids
  */
-export function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
+function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
     return Object.keys(roleTodoIdMap);
 }
 
@@ -36,7 +18,7 @@ export function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
 
  * @param roleRequestMap a map associating role titles with BasecampTodoRequest objects
  */
-export function getCurrentEventRoles(currentRoleRequestMap: RoleRequestMap): string[] {
+function getCurrentEventRoles(currentRoleRequestMap: RoleRequestMap): string[] {
     return Object.keys(currentRoleRequestMap);
 }
 
@@ -52,10 +34,10 @@ export function getRoles(roleRequestMap: RoleRequestMap, currentRoleTodoIdMap: R
     const originalRoles: string[] = getOriginalEventRoles(currentRoleTodoIdMap);
 
     switch(roleStatus) {
-        case RoleStatus.OBSOLETE:
+        case RoleStatus.REMOVED:
             return originalRoles.filter(role => !currentRoles.includes(role));
 
-        case RoleStatus.SURVIVING:
+        case RoleStatus.EXISTING:
             return currentRoles.filter(role => originalRoles.includes(role));
         
         case RoleStatus.NEW:

--- a/src/main/role.ts
+++ b/src/main/role.ts
@@ -1,0 +1,64 @@
+import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
+import { getRowBasecampMapping } from "./row";
+
+export enum RoleStatus {
+    OBSOLETE,
+    SURVIVING,
+    NEW
+}
+
+/**
+ * Gets the roleTodoIdMap object from the RowBasecampMapping object.
+ * Used for downstream processing
+ * 
+ * @param row a list of all the current roles associated with the row including the lead role. This may be identical to the original roles
+ * @returns a map that associates role titles with basecamp todo ids
+ */
+export function getRoleTodoIdMap(row: Row) {
+    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
+    if(savedRowBasecampMapping == null) {
+        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null! Unable to proceed with updating the todo!");
+    }
+    return savedRowBasecampMapping.roleTodoIdMap
+}
+
+/**
+ * Gets a list of roles from a roleTodoIdMap
+ * 
+ * @param roleTodoIdMap a map associating an event's roles with todo ids
+ */
+export function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
+    return Object.keys(roleTodoIdMap);
+}
+
+/**
+ * Gets a list of roles from a roleRequestMap map
+
+ * @param roleRequestMap a map associating role titles with BasecampTodoRequest objects
+ */
+export function getCurrentEventRoles(currentRoleRequestMap: RoleRequestMap): string[] {
+    return Object.keys(currentRoleRequestMap);
+}
+
+/**
+ * Gets a list of roles (i.e. obsolete, new, surviving) by comparing the original and current roles together
+ * 
+ * @param roleRequestMap a map associating an event's roles with api request bodies
+ * @param currentRoleTodoIdMap a map associating an event's roles to existing todo ids, that is currently saved in the document properties
+ * @returns an array of obsolete roles
+ */
+export function getRoles(roleRequestMap: RoleRequestMap, currentRoleTodoIdMap: RoleTodoIdMap, roleStatus: RoleStatus): string[] {
+    const currentRoles: string[] = getCurrentEventRoles(roleRequestMap);
+    const originalRoles: string[] = getOriginalEventRoles(currentRoleTodoIdMap);
+
+    switch(roleStatus) {
+        case RoleStatus.OBSOLETE:
+            return originalRoles.filter(role => !currentRoles.includes(role));
+
+        case RoleStatus.SURVIVING:
+            return currentRoles.filter(role => originalRoles.includes(role));
+        
+        case RoleStatus.NEW:
+            return currentRoles.filter(role => !originalRoles.includes(role));
+    }
+}

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -1,4 +1,5 @@
 import { InvalidHashError } from "./error/invalidHashError";
+import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
 import { RowMissingIdError } from "./error/rowMissingIdError";
 import { RowNotSavedError } from "./error/rowNotSavedError";
 import { getPersonId } from "./people";
@@ -367,7 +368,7 @@ function getHelperGroups(row: Row): HelperGroup[] {
             const trimmedHelperNameList: string = helperNameList.trim();
             helperGroups.push(getHelperGroupFromNameList(trimmedHelperNameList, role));
             
-        } else if(helperLine != "") {
+        } else if(helperLine !== "") {
             helperGroups.push(getHelperGroupFromNameList(helperLine, undefined));
         }
     }
@@ -407,4 +408,19 @@ function getHelperGroupFromNameList(helperNameList: string, role: string | undef
  */
 export function clearAllRowMetadata(): void {
     deleteAllDocumentProperties();
+}
+
+/**
+ * Gets the roleTodoIdMap object from the RowBasecampMapping object.
+ * Used for downstream processing
+ * 
+ * @param row a list of all the current roles associated with the row including the lead role. This may be identical to the original roles
+ * @returns a map that associates role titles with basecamp todo ids
+ */
+export function getRoleTodoIdMap(row: Row) {
+    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
+    if(savedRowBasecampMapping === null) {
+        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null! Unable to proceed with updating the todo!");
+    }
+    return savedRowBasecampMapping.roleTodoIdMap;
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -89,7 +89,7 @@ export function hasId(row: Row): boolean {
  * @param row the row's contents to write
  * @param roleTodoIdMap a map that has role titles as the keys and todo ids as the values
  */
-export function saveRow(row: Row, roleTodoIdMap: Map<string, string>): void {
+export function saveRow(row: Row, roleTodoIdMap: { [key: string]: string }): void {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -291,13 +291,24 @@ function getLeadsNames(row: Row): string[] {
  */
 function getBasecampTodoDescription(row: Row): string {
     const location: string = `WHERE: ${row.where.value ?? "N\\A"}`;
+
+    const locales: Intl.LocalesArgument = 'en-us';
+    const options: Intl.DateTimeFormatOptions = {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+    }
+    const startTime: string = row.startTime.toLocaleTimeString(locales, options);
+    const endTime: string = row.endTime.toLocaleTimeString(locales, options);
+
+    const time: string = `\n\nWHEN: ${startTime} - ${endTime}`;
     const inCharge: string = `\n\nIN CHARGE: ${row.inCharge.value ?? "N\\A"}`;
     const helpers: string = `\n\nHELPERS:\n${row.helpers.value ?? "N\\A"}`;
     const foodLead: string = `\n\nFOOD LEAD: ${row.foodLead.value ?? "N\\A"}`;
     const childcare: string = `\n\nCHILDCARE: ${row.childcare.value ?? "N\\A"}`;
     const notes: string = `\n\nNOTES: ${row.notes.value ?? "N\\A"}`;
 
-    return location + inCharge + helpers + foodLead + childcare + notes;
+    return location + time + inCharge + helpers + foodLead + childcare + notes;
 }
 
 /**

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -13,6 +13,7 @@ const MONTH_LENGTH: number = 2;
 const DAY_LENGTH: number = 2;
 const NEW_LINE_DELIM = "\n";
 const COLON_DELIM = ":";
+const LEAD_ROLE_TITLE = "Lead";
 
 declare interface HelperGroup {
     readonly role?: string,
@@ -229,15 +230,14 @@ export function getBasecampTodoRequestsForRow(row: Row): Map<string, BasecampTod
  */
 export function getBasecampTodoForLeads(row: Row, basecampTodoRequests: Map<string, BasecampTodoRequest>): void {
 
-    const roleTitle = "Lead"
-    const basecampTodoContent: string = `${roleTitle}: ${row.what.value}`;
+    const basecampTodoContent: string = `${LEAD_ROLE_TITLE}: ${row.what.value}`;
     const leadIds: string[] = getLeadsBasecampIds(row);
     const basecampTodoDescription: string = getBasecampTodoDescription(row);
     const basecampDueDate: string = getBasecampDueDate(row);
 
     if(leadIds.length > 0) {
         const leadsRequest: BasecampTodoRequest = getBasecampTodoRequest(basecampTodoContent, basecampTodoDescription, leadIds, leadIds, false, basecampDueDate);
-        basecampTodoRequests.set( roleTitle, leadsRequest );
+        basecampTodoRequests.set( LEAD_ROLE_TITLE, leadsRequest );
     } else {
         Logger.log(`${getLeadsNames(row)} do not have any Basecamp ids. row: ${row}`);
     }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -167,7 +167,7 @@ function getSavedHash(row: Row): string | null {
  * @param row the row to retrieve the RowBasecampMapping object for
  * @returns the RowBasecampMapping object or null if the row cannot be found in the PropertiesService
  */
-function getRowBasecampMapping(row: Row): RowBasecampMapping | null {
+export function getRowBasecampMapping(row: Row): RowBasecampMapping | null {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -283,8 +283,8 @@ function getLeadsNames(row: Row): string[] {
  */
 function getBasecampTodoDescription(row: Row): string {
     const location: string = `WHERE: ${row.where.value ?? "N\\A"}`;
-    const inCharge: string = `\n\nIN CHARAGE: ${row.inCharge.value ?? "N\\A"}`;
-    const helpers: string = `\n\nHELPERS: ${row.helpers.value ?? "N\\A"}`;
+    const inCharge: string = `\n\nIN CHARGE: ${row.inCharge.value ?? "N\\A"}`;
+    const helpers: string = `\n\nHELPERS:\n${row.helpers.value ?? "N\\A"}`;
     const foodLead: string = `\n\nFOOD LEAD: ${row.foodLead.value ?? "N\\A"}`;
     const childcare: string = `\n\nCHILDCARE: ${row.childcare.value ?? "N\\A"}`;
     const notes: string = `\n\nNOTES: ${row.notes.value ?? "N\\A"}`;

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -125,6 +125,7 @@ export function hasBeenSaved(row: Row): boolean {
  * @returns boolean representing whether the given row's contents has been changed or not
  */
 export function hasChanged(row: Row): boolean {
+    Logger.log("Checking if the row has changed...\n")
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -221,7 +221,7 @@ export function getBasecampTodoRequestsForRow(row: Row): RoleRequestMap {
     const leadsRoleRequestMap: RoleRequestMap = getBasecampTodoForLeads(row);
     const helperRoleRequestMap: RoleRequestMap = getBasecampTodosForHelpers(row);
 
-    const allRoleRequestMap = {...leadsRoleRequestMap, ...helperRoleRequestMap};
+    const allRoleRequestMap: RoleRequestMap = {...leadsRoleRequestMap, ...helperRoleRequestMap};
 
     return allRoleRequestMap;
 }
@@ -337,7 +337,7 @@ export function getBasecampTodosForHelpers(row: Row): RoleRequestMap {
         const basecampDueDate: string = getBasecampDueDate(row);
 
         if(assigneeIds.length > 0) {
-            const basecampTodoRequest = getBasecampTodoRequest(basecampTodoContent, basecampTodoDescription, assigneeIds, leadIds, false, basecampDueDate);
+            const basecampTodoRequest: BasecampTodoRequest = getBasecampTodoRequest(basecampTodoContent, basecampTodoDescription, assigneeIds, leadIds, false, basecampDueDate);
             helperRoleRequestMap[roleTitle] = basecampTodoRequest;
 
         } else {

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -90,7 +90,7 @@ export function hasId(row: Row): boolean {
  * @param row the row's contents to write
  * @param roleTodoIdMap a map that has role titles as the keys and todo ids as the values
  */
-export function saveRow(row: Row, roleTodoIdMap: { [key: string]: string }): void {
+export function saveRow(row: Row, roleTodoIdMap: RoleTodoIdMap): void {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -36,14 +36,14 @@ interface CellData {
  * @returns an array of event rows from all of the daily active tabs of the spreadsheet
  */
 export function getEventRowsFromSpreadsheet(): Row[] {
-    console.log("Getting event rows from spreadsheet...\n");
+    Logger.log("Getting event rows from spreadsheet...\n");
     
     const tabs: Sheet[] = getAllSpreadsheetTabs();
     const dailyActiveTabs: Sheet[] = getActiveDailyTabs(tabs);
     // Fetches all event rows from all of the daily active tabs
     const eventRows: Row[] = dailyActiveTabs.flatMap((dailyActiveTab) => getRowsWithEvents(dailyActiveTab));
     
-    console.log(`Found ${eventRows.length} active rows from the spreadsheet...`)
+    Logger.log(`Found ${eventRows.length} active rows from the spreadsheet...`)
     return eventRows;
 }
 

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -36,11 +36,14 @@ interface CellData {
  * @returns an array of event rows from all of the daily active tabs of the spreadsheet
  */
 export function getEventRowsFromSpreadsheet(): Row[] {
+    console.log("Getting event rows from spreadsheet...\n");
+    
     const tabs: Sheet[] = getAllSpreadsheetTabs();
     const dailyActiveTabs: Sheet[] = getActiveDailyTabs(tabs);
     // Fetches all event rows from all of the daily active tabs
     const eventRows: Row[] = dailyActiveTabs.flatMap((dailyActiveTab) => getRowsWithEvents(dailyActiveTab));
-
+    
+    console.log(`Found ${eventRows.length} active rows from the spreadsheet...`)
     return eventRows;
 }
 

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,4 +1,4 @@
-import { getBasecampProjectUrl, sendBasecampDeleteRequest, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 
 const TODOLISTS_PATH: string = '/todolists/';
 const TODO_PATH: string = '/todos/';

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,6 +1,5 @@
 import { getBasecampProjectUrl, PROJECT_ID, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 import { BasecampRequestMissingError } from "./error/basecampRequestMissingError";
-import { DEFAULT_TODOLIST_IDENTIFIER } from "./main";
 import { getRoles, RoleStatus } from "./role";
 
 const TODOLISTS_PATH: string = '/todolists/';
@@ -11,6 +10,11 @@ const TODO_JSON_PATH: string = '/todos' + JSON_PATH;
 const TRASHED_TODO_JSON_PATH: string = '/status/trashed' + JSON_PATH;
 
 export const TODOLIST_ID: string= "7865336721";
+
+const DEFAULT_TODOLIST_IDENTIFIER: TodolistIdentifier = {
+    projectId: PROJECT_ID,
+    todolistId: TODOLIST_ID
+};
 
 /**
  * Creates a todo in Basecamp

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -30,6 +30,10 @@ export function updateTodo(todo: BasecampTodoRequest, todoIdentifier: TodoIdenti
     sendBasecampPutRequest(getUpdateTodoUrl(todoIdentifier), todo);
 }
 
+export function deleteTodo() {
+    
+}
+
 function getCreateTodoUrl(todolistIdentifier: TodolistIdentifier): string {
     return getBasecampProjectUrl(todolistIdentifier.projectId) + TODOLISTS_PATH + todolistIdentifier.todolistId + TODO_JSON_PATH;
 }

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,4 +1,5 @@
 import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { BasecampRequestMissingError } from "./error/basecampRequestMissingError";
 
 const TODOLISTS_PATH: string = '/todolists/';
 const TODO_PATH: string = '/todos/';
@@ -16,11 +17,16 @@ export const TODOLIST_ID: string= "7865336721";
  * @param todolistIdentifier id of the todolist where the todo will be created in
  * @returns the id of the created todo. This must be saved by the caller to update this todo in the future.
  */
-export function createTodo(todo: BasecampTodoRequest, todolistIdentifier: TodolistIdentifier): string {
-    Logger.log(`Creating new "${todo.content}" todo...\n`)
-    const rawTodoResponse: JsonData = sendBasecampPostRequest(getCreateTodoUrl(todolistIdentifier), todo);
-    const todoResponse: BasecampTodoResponse = rawTodoResponse as BasecampTodoResponse;
-    return todoResponse.id;
+export function createTodo(request: BasecampTodoRequest | undefined, todolistIdentifier: TodolistIdentifier): string {
+    
+    if(request == undefined) {
+        throw new BasecampRequestMissingError("Missing basecamp request!");
+    } else {
+        Logger.log(`Creating new todo: "${request.content}"...\n`)
+        const rawTodoResponse: JsonData = sendBasecampPostRequest(getCreateTodoUrl(todolistIdentifier), request);
+        const todoResponse: BasecampTodoResponse = rawTodoResponse as BasecampTodoResponse;
+        return todoResponse.id;
+    }
 }
 
 /**
@@ -30,8 +36,14 @@ export function createTodo(todo: BasecampTodoRequest, todolistIdentifier: Todoli
  * @param todo payload to replace the existing todo
  * @param todoIdentifier id of the existing todo to replace
  */
-export function updateTodo(todo: BasecampTodoRequest, todoIdentifier: TodoIdentifier): void {
-    sendBasecampPutRequest(getUpdateTodoUrl(todoIdentifier), todo);
+export function updateTodo(request: BasecampTodoRequest | undefined, todoIdentifier: TodoIdentifier): void {
+
+    if(request == undefined) {
+        throw new BasecampRequestMissingError("Missing basecamp request!");
+    } else {
+        Logger.log(`Updating existing todo: "${request.content}"...\n`)
+        sendBasecampPutRequest(getUpdateTodoUrl(todoIdentifier), request);
+    }
 }
 
 

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,9 +1,12 @@
-import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { getBasecampProjectUrl, sendBasecampDeleteRequest, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 
 const TODOLISTS_PATH: string = '/todolists/';
 const TODO_PATH: string = '/todos/';
+const RECORDINGS_PATH: string = '/recordings/';
 const JSON_PATH: string = '.json';
 const TODO_JSON_PATH: string = '/todos' + JSON_PATH;
+const TRASHED_TODO_JSON_PATH: string = '/status/trashed' + JSON_PATH;
+
 export const TODOLIST_ID: string= "7865336721";
 
 /**
@@ -14,6 +17,7 @@ export const TODOLIST_ID: string= "7865336721";
  * @returns the id of the created todo. This must be saved by the caller to update this todo in the future.
  */
 export function createTodo(todo: BasecampTodoRequest, todolistIdentifier: TodolistIdentifier): string {
+    Logger.log(`Creating new "${todo.content}" todo...\n`)
     const rawTodoResponse: JsonData = sendBasecampPostRequest(getCreateTodoUrl(todolistIdentifier), todo);
     const todoResponse: BasecampTodoResponse = rawTodoResponse as BasecampTodoResponse;
     return todoResponse.id;
@@ -30,8 +34,15 @@ export function updateTodo(todo: BasecampTodoRequest, todoIdentifier: TodoIdenti
     sendBasecampPutRequest(getUpdateTodoUrl(todoIdentifier), todo);
 }
 
-export function deleteTodo() {
-    
+
+/**
+ * Trashes a todo in Basecamp. 
+ * 
+ * @param todo payload to replace the existing todo
+ * @param todoIdentifier id of the existing todo to replace
+ */
+export function deleteTodo(todoIdentifier: TodoIdentifier): void {
+    sendBasecampDeleteRequest(getDeleteTodoUrl(todoIdentifier));
 }
 
 function getCreateTodoUrl(todolistIdentifier: TodolistIdentifier): string {
@@ -40,6 +51,10 @@ function getCreateTodoUrl(todolistIdentifier: TodolistIdentifier): string {
 
 function getUpdateTodoUrl(todoIdentifier: TodoIdentifier): string {
     return getBasecampProjectUrl(todoIdentifier.projectId) + TODO_PATH + todoIdentifier.todoId + JSON_PATH;
+}
+
+function getDeleteTodoUrl(todoIdentifier: TodoIdentifier): string {
+    return getBasecampProjectUrl(todoIdentifier.projectId) + RECORDINGS_PATH + todoIdentifier.todoId + TRASHED_TODO_JSON_PATH;
 }
 
 /**

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -42,7 +42,8 @@ export function updateTodo(todo: BasecampTodoRequest, todoIdentifier: TodoIdenti
  * @param todoIdentifier id of the existing todo to replace
  */
 export function deleteTodo(todoIdentifier: TodoIdentifier): void {
-    sendBasecampDeleteRequest(getDeleteTodoUrl(todoIdentifier));
+    Logger.log("Deleting todo...\n")
+    sendBasecampPutRequest(getDeleteTodoUrl(todoIdentifier), {});
 }
 
 function getCreateTodoUrl(todolistIdentifier: TodolistIdentifier): string {

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -100,7 +100,7 @@ export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoIdMap {
     const roleTodoIdMap: RoleTodoIdMap = {};
 
     Object.keys(roleRequestMap).forEach( role => {
-        let request = roleRequestMap[role];
+        let request: BasecampTodoRequest = roleRequestMap[role];
         let basecampTodoId: string = createTodo(request, DEFAULT_TODOLIST_IDENTIFIER)
         roleTodoIdMap[role] = basecampTodoId;
     });
@@ -158,11 +158,11 @@ export function deleteObsoleteTodos(roleRequestMap: RoleRequestMap, currentRoleT
  */
 export function getObsoleteTodosIds(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
 
-    const obsoleteTodoIds = [];
+    const obsoleteTodoIds: string[] = [];
     
     for(const role of obsoleteRoles) {
         Logger.log(`Found removed role: ${role}!\n`);
-        let todoId = roleTodoIdMap[role];
+        let todoId: string = roleTodoIdMap[role];
         obsoleteTodoIds.push(todoId);
     }
 
@@ -183,8 +183,8 @@ export function updateTodosForExistingRoles(roleRequestMap: RoleRequestMap, role
     const existingRoles: string[] = getRoles(roleRequestMap, roleTodoIdMap, RoleStatus.EXISTING);
 
     for(const role of existingRoles) {
-        let existingTodoId = roleTodoIdMap[role];
-        let request = roleRequestMap[role];
+        let existingTodoId: string = roleTodoIdMap[role];
+        let request: BasecampTodoRequest = roleRequestMap[role];
 
         if(request === undefined) {
             throw new BasecampRequestMissingError("Missing basecamp request!");
@@ -222,7 +222,7 @@ export function createTodosForNewRoles(roleRequestMap: RoleRequestMap, roleTodoI
     if(newRoles.length > 0) {
         Logger.log(`New role(s) detected: ${newRoles}\n`);
         for(const role of newRoles) {
-            let request = roleRequestMap[role];
+            let request: BasecampTodoRequest = roleRequestMap[role];
 
             if(request === undefined) {
                 throw new BasecampRequestMissingError("Missing basecamp request!");

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,5 +1,7 @@
-import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { getBasecampProjectUrl, PROJECT_ID, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 import { BasecampRequestMissingError } from "./error/basecampRequestMissingError";
+import { DEFAULT_TODOLIST_IDENTIFIER } from "./main";
+import { getRoles, RoleStatus } from "./role";
 
 const TODOLISTS_PATH: string = '/todolists/';
 const TODO_PATH: string = '/todos/';
@@ -91,4 +93,141 @@ export function getBasecampTodoRequest(content: string, description: string, ass
         notify: notify,
         due_on: basecampDueDate
     }
+}
+
+/**
+ * Sends requests to create new Basecamp Todos
+ * 
+ * @param basecampRequests array of BasecampTodoRequest objects to send
+ * @returns a map that associates role titles with basecamp todo ids
+ */
+export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoIdMap {
+    const roleTodoIdMap: RoleTodoIdMap = {};
+
+    Object.keys(roleRequestMap).forEach( role => {
+        let request = roleRequestMap[role];
+        let basecampTodoId: string = createTodo(request, DEFAULT_TODOLIST_IDENTIFIER)
+        roleTodoIdMap[role] = basecampTodoId;
+    });
+
+    return roleTodoIdMap;
+}
+
+/**
+ * Deletes the list of todos based on their todo ids
+ * 
+ * @param todoIds todo ids corresponding to todos to delete
+ */
+export function deleteTodos(todoIds: string[]): void {
+
+    for(const id of todoIds) {
+
+        let todoIdentifier: TodoIdentifier = {
+            projectId: PROJECT_ID,
+            todoId: id
+        }
+
+        deleteTodo(todoIdentifier);
+    }
+}
+
+/**
+ * Deletes todos associated with helper groups that are no longer present on the event row.
+ * The first line checks whether there are any rows present in the original roles that are not present in the current roles (indicating an obsolete role)
+ * 
+ * @param roleRequestMap a map associating an event's roles with api request bodies
+ * @param currentRoleTodoIdMap a map associating an event's roles to existing todo ids, that is currently saved in the document properties
+ * @returns a string array of obsolete roles that were deleted
+ */
+export function deleteObsoleteTodos(roleRequestMap: RoleRequestMap, currentRoleTodoIdMap: RoleTodoIdMap): string[] {
+    Logger.log("Checking for obsolete roles...\n")
+    const obsoleteRoles: string[] = getRoles(roleRequestMap, currentRoleTodoIdMap, RoleStatus.OBSOLETE);
+
+    if(obsoleteRoles.length > 0) {
+        const obsoleteTodoIds: string[] = getObsoleteTodosIds(obsoleteRoles, currentRoleTodoIdMap);
+        deleteTodos(obsoleteTodoIds);
+
+    } else {
+        Logger.log("No obsolete roles detected!\n");
+    }
+
+    return obsoleteRoles;
+}
+
+/**
+ * Gets a list of obsolete todo ids based off of the obsolete roels roles by comparing the original and current roles together
+ * 
+ * @param obsoleteRoles an array of obsolete roles
+ * @param roleTodoIdMap a map associating an event's roles with todo ids
+ * @returns an array of obsolete roles
+ */
+export function getObsoleteTodosIds(obsoleteRoles: string[], roleTodoIdMap: RoleTodoIdMap): string[] {
+
+    const obsoleteTodoIds = []
+    
+    for(const role of obsoleteRoles) {
+        Logger.log(`Found obsolete role: ${role}!\n`)
+        let todoId = roleTodoIdMap[role];
+        obsoleteTodoIds.push(todoId);
+    }
+
+    return obsoleteTodoIds
+}
+
+/**
+ * Updates todos for existing roles. Gets the request body from the roleRequestMap map
+ * Gets the existing todo id from the roleTodoIdMap object
+ * 
+ * @param roleRequestMap a map associating role titles with BasecampTodoRequest objects
+ * @param roleTodoIdMap a map associating an event's roles to existing todo ids that is currently saved in the document properties
+ * @returns an object mapping surviving roles with their existing todo ids
+ */
+export function updateTodosForSurvivingRoles(roleRequestMap: RoleRequestMap, roleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
+    Logger.log("Updating todos for surviving roles...");
+    const survivingRoleTodoIdMap: RoleTodoIdMap = {};
+    const survivingRoles: string[] = getRoles(roleRequestMap, roleTodoIdMap, RoleStatus.SURVIVING);
+
+    for(const role of survivingRoles) {
+        let survivingTodoId = roleTodoIdMap[role];
+        let request = roleRequestMap[role];
+
+        let todoIdentifier: TodoIdentifier = {
+            projectId: PROJECT_ID,
+            todoId: survivingTodoId
+        }
+
+        updateTodo(request, todoIdentifier);
+
+        survivingRoleTodoIdMap[role] = survivingTodoId;
+    }
+
+    return survivingRoleTodoIdMap;
+}
+
+/**
+ * Create todos for new roles. Gets the request body from the roleRequestMap map
+ * 
+ * @param roleRequestMap a map associating an event's roles with api request bodies
+ * @param roleTodoIdMap a map associating an event's roles to existing todo ids that is currently saved in the document properties
+ * @returns an object mapping new roles with their newly created todo ids
+ */
+export function createTodosForNewRoles(roleRequestMap: RoleRequestMap, roleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
+    Logger.log("Checking for new roles...\n");
+
+    const newRoles: string[] = getRoles(roleRequestMap, roleTodoIdMap, RoleStatus.NEW);
+    const newRoleTodoIdMap: RoleTodoIdMap = {};
+    
+    if(newRoles.length > 0) {
+        Logger.log(`New role(s) detected: ${newRoles}\n`)
+        for(const role of newRoles) {
+            let request = roleRequestMap[role];
+            let newTodoId = createTodo(request, DEFAULT_TODOLIST_IDENTIFIER);
+            newRoleTodoIdMap[role] = newTodoId;
+        }
+
+    } else {
+        Logger.log("No new roles detected!\n")
+    }
+
+    return newRoleTodoIdMap;
 }

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -94,7 +94,7 @@ declare interface Person extends JsonObject {
   name: string,
 }
 
-// The key string represents a rowId and the value represents a stringified Json object that has the row hash and a RoleRequestMap as properties
-type DocumentProperties = { [key: string]: string };
+// The key string represents a rowId and the value represents a RowBasecampMapping
+type DocumentProperties = { [key: string]: RowBasecampMapping };
 
 type RoleRequestMap = { [key: string]: BasecampTodoRequest }

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -30,9 +30,11 @@ declare interface Row {
   readonly notes: Text
 }
 
+type RoleTodoIdMap = { [key: string]: string };
+
 declare interface RowBasecampMapping {
   rowHash: string,
-  roleTodoIdMap: { [key: string]: string }
+  roleTodoIdMap: RoleTodoIdMap
 }
 
 type HTTPResponse = GoogleAppsScript.URL_Fetch.HTTPResponse;
@@ -90,3 +92,5 @@ declare interface Person extends JsonObject {
   id: string,
   name: string,
 }
+
+type DocumentProperties = { [key: string]: string };

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -32,7 +32,7 @@ declare interface Row {
 
 declare interface RowBasecampMapping {
   rowHash: string,
-  roleTodoIdMap: Map<string, string>
+  roleTodoIdMap: { [key: string]: string }
 }
 
 type HTTPResponse = GoogleAppsScript.URL_Fetch.HTTPResponse;

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -94,3 +94,5 @@ declare interface Person extends JsonObject {
 }
 
 type DocumentProperties = { [key: string]: string };
+
+type RoleRequestMap = { [key: string]: BasecampTodoRequest }

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -32,7 +32,7 @@ declare interface Row {
 
 declare interface RowBasecampMapping {
   rowHash: string,
-  basecampTodoIds: string[]
+  roleTodoIdMap: Map<string, string>
 }
 
 type HTTPResponse = GoogleAppsScript.URL_Fetch.HTTPResponse;

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -30,6 +30,7 @@ declare interface Row {
   readonly notes: Text
 }
 
+// The key string represents a role and the value represents a todoId
 type RoleTodoIdMap = { [key: string]: string };
 
 declare interface RowBasecampMapping {
@@ -93,6 +94,7 @@ declare interface Person extends JsonObject {
   name: string,
 }
 
+// The key string represents a rowId and the value represents a stringified Json object that has the row hash and a RoleRequestMap as properties
 type DocumentProperties = { [key: string]: string };
 
 type RoleRequestMap = { [key: string]: BasecampTodoRequest }


### PR DESCRIPTION
### Update Existing Todos When OneStop Is Changed

This PR gives our code the ability to update existing todos whenever a change is made in the OneStop and the script is triggered. 

I manually tested the following scenarios and the updated code was able to successfully handle them by editing and moditying the todos in basecamp as expected:

1. Changing the location
2. Changing the date
3. Rearranging roles
4. Adding/removing new helper groups (i.e. food: )
5. Running the script after changes and again without changes ensuring that it doesn't make duplicate todos.

I also modified the document property methods to store the todo ids in a more descriptive way, separating them into different roles in an object.

