### PR TITLE
Adds logic to load the members and couples table from the Onestop

### DIFF
--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -1,0 +1,346 @@
+// Mock PropertiesService and SpreadsheetApp must be imported and set before imported modules require these global objects
+import { PropertiesService, SpreadsheetApp } from 'gasmask';
+global.PropertiesService = PropertiesService;
+global.SpreadsheetApp = SpreadsheetApp;
+
+import { getRandomlyGeneratedAliasMap, getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, getRandomlyGeneratedRange, getRandomlyGeneratedSheet, Mock } from './testUtils';
+import { TabNotFoundError } from '../src/main/error/tabNotFoundError';
+
+const NAME_COLUMN_INDEX: number = 0;
+const GENDER_COLUMN_INDEX: number = 1;
+const MARRIED_COLUMN_INDEX: number = 2;
+const PARENT_COLUMN_INDEX: number = 3;
+const CLASS_COLUMN_INDEX: number = 4;
+const ALTERNATE_NAMES_COLUMN_INDEX: number = 5;
+
+describe("MEMBER_MAP", () => {
+    it("should return the member map from the script properties when it is present", () => {
+        const memberMapMock: MemberMap = getRandomlyGeneratedMemberMap();
+
+        jest.doMock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(() => JSON.stringify(memberMapMock)),
+        }));
+        
+        // Import the MEMBER_MAP with the mocked propertiesService
+        const { MEMBER_MAP } = require('../src/main/members');
+
+        expect(MEMBER_MAP).toEqual(memberMapMock);
+    });
+
+    it("should return an empty map when there is no member map present in the script properties", () => {
+        jest.doMock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(() => null),
+        }));
+
+        // Import the MEMBER_MAP with the mocked propertiesService
+        const { MEMBER_MAP } = require('../src/main/members');
+
+        expect(MEMBER_MAP).toStrictEqual({});
+    });
+});
+
+describe("ALIASES_MAP", () => {
+    it("should return the aliases map from the script properties when it is present", () => {
+        const aliasesMapMock: AliasMap = getRandomlyGeneratedAliasMap();
+
+        jest.doMock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(() => JSON.stringify(aliasesMapMock)),
+        }));
+        
+        // Import the MEMBER_MAP with the mocked propertiesService
+        const { ALIASES_MAP } = require('../src/main/members');
+
+        expect(ALIASES_MAP).toEqual(aliasesMapMock);
+    });
+
+    it("should return an empty map when there is no aliases map present in the script properties", () => {
+        jest.doMock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(() => null),
+        }));
+
+        // Import the MEMBER_MAP with the mocked propertiesService
+        const { ALIASES_MAP } = require('../src/main/members');
+
+        expect(ALIASES_MAP).toStrictEqual({});
+    });
+});
+
+describe("loadMembersFromOnestopIntoScriptProperties", () => {
+    it("should load the members and couples table from the onestop into the script properties when the members and couples table are present on the onestop", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(5, 1);
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "memberName1";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "memberName2";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "memberName3";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "alias5,alias6";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "memberName4";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "alias7,alias8";
+        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "memberName5";
+        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "alias9,alias10";
+        
+        const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(2);
+        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
+        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
+        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        couplesTableSheetMock.getName = jest.fn(() => "Couples");
+        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
+
+        couplesDataValuesMock[1] = ["memberName2", "memberName3", "coupleAlias1,coupleAlias2"];
+        couplesDataValuesMock[2] = ["memberName4", "memberName5", "coupleAlias3,coupleAlias4"];
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        sheetsMock.push(couplesTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+        loadMembersFromOnestopIntoScriptProperties();
+
+        const expectedMemberMap: MemberMap = {
+            memberName1: {name: "memberName1", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
+            memberName2: {name: "memberName2", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
+            memberName3: {name: "memberName3", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
+            memberName4: {name: "memberName4", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
+            memberName5: {name: "memberName5", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
+        };
+
+        const expectedAliasMap: AliasMap = {
+            alias1: ["memberName1"],
+            alias2: ["memberName1"],
+            alias3: ["memberName2"],
+            alias4: ["memberName2"],
+            alias5: ["memberName3"],
+            alias6: ["memberName3"],
+            alias7: ["memberName4"],
+            alias8: ["memberName4"],
+            alias9: ["memberName5"],
+            alias10: ["memberName5"],
+            coupleAlias1: ["memberName2", "memberName3"],
+            coupleAlias2: ["memberName2", "memberName3"],
+            coupleAlias3: ["memberName4", "memberName5"],
+            coupleAlias4: ["memberName4", "memberName5"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledTimes(2);
+        expect(setScriptPropertyMock).toHaveBeenNthCalledWith(1, "MEMBER_MAP", JSON.stringify(expectedMemberMap));
+        expect(setScriptPropertyMock).toHaveBeenNthCalledWith(2, "ALIASES_MAP", JSON.stringify(expectedAliasMap));
+    });
+
+    it("should throw a TabNotFoundError error when the Members tab does not exist on the onestop", () => {
+        jest.doMock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => Array.from({length: 10}, getRandomlyGeneratedSheet)),
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+
+        expect(() => loadMembersFromOnestopIntoScriptProperties()).toThrow(new TabNotFoundError("No Members tab found"));
+    });
+
+    it("should throw a TabNotFoundError error when the Couples tab does not exist on the onestop", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable();
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+
+        expect(() => loadMembersFromOnestopIntoScriptProperties()).toThrow(new TabNotFoundError("No Couples tab found"));
+    });
+
+    it("should load an empty object into script properties for the members map when the members table is empty", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(0);
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(3);
+        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
+        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
+        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        couplesTableSheetMock.getName = jest.fn(() => "Couples");
+        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        sheetsMock.push(couplesTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+        loadMembersFromOnestopIntoScriptProperties();
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("MEMBER_MAP", "{}");
+    });
+
+    it("should load a object of just the member alternate names when the couples table is empty", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "name1";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "name2";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
+
+        const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
+        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
+        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
+        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        couplesTableSheetMock.getName = jest.fn(() => "Couples");
+        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        sheetsMock.push(couplesTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+        loadMembersFromOnestopIntoScriptProperties();
+
+        const expected: AliasMap = {
+            alias1: ["name1"],
+            alias2: ["name1"],
+            alias3: ["name2"],
+            alias4: ["name2"],
+        };
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
+    });
+
+    it("should map an alternate name to multiple people when multiple people share the same alternate name", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "name1";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "name2";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias2,alias3";
+
+        const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
+        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
+        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
+        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        couplesTableSheetMock.getName = jest.fn(() => "Couples");
+        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        sheetsMock.push(couplesTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+        loadMembersFromOnestopIntoScriptProperties();
+
+        const expected: AliasMap = {
+            alias1: ["name1"],
+            alias2: ["name1", "name2"],
+            alias3: ["name2"],
+        };
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
+    });
+
+    it("should map an alias to both a person and a couple when a person's alternate name is the same as a couple's alias", () => {
+        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(3, 1);
+        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
+        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
+        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        membersTableSheetMock.getName = jest.fn(() => "Members");
+        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
+
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "memberName";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "husbandName";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "wifeName";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "alias5,alias6";
+        
+        const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(1);
+        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
+        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
+        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
+        couplesTableSheetMock.getName = jest.fn(() => "Couples");
+        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
+
+        couplesDataValuesMock[1] = ["husbandName", "wifeName", "alias1"];
+
+        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
+        sheetsMock.push(membersTableSheetMock);
+        sheetsMock.push(couplesTableSheetMock);
+        jest.mock("../src/main/scan", () => ({
+            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            getScriptProperty: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
+        loadMembersFromOnestopIntoScriptProperties();
+
+        const expected: AliasMap = {
+            alias1: ["memberName", "husbandName", "wifeName"],
+            alias2: ["memberName"],
+            alias3: ["husbandName"],
+            alias4: ["husbandName"],
+            alias5: ["wifeName"],
+            alias6: ["wifeName"],
+        };
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
+    });
+});

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -1,5 +1,6 @@
 // Mock PropertiesService and SpreadsheetApp must be imported and set before imported modules require these global objects
-import { PropertiesService, SpreadsheetApp } from 'gasmask';
+import { Logger, PropertiesService, SpreadsheetApp } from 'gasmask';
+global.Logger = Logger;
 global.PropertiesService = PropertiesService;
 global.SpreadsheetApp = SpreadsheetApp;
 
@@ -74,16 +75,16 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersTableSheetMock.getName = jest.fn(() => "Members");
         membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
 
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "memberName1";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "memberName2";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
-        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "memberName3";
-        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "alias5,alias6";
-        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "memberName4";
-        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "alias7,alias8";
-        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "memberName5";
-        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "alias9,alias10";
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "Mary Brown";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "Robert White";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "Robert,Robert W";
+        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "Emily White";
+        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "Emily,Emily W";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(2);
         const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
@@ -92,8 +93,8 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesTableSheetMock.getName = jest.fn(() => "Couples");
         couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
-        couplesDataValuesMock[1] = ["memberName2", "memberName3", "coupleAlias1,coupleAlias2"];
-        couplesDataValuesMock[2] = ["memberName4", "memberName5", "coupleAlias3,coupleAlias4"];
+        couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "James/Mary,Browns"];
+        couplesDataValuesMock[2] = ["Robert White", "Emily White", "Robert/Emily,Whites"];
 
         const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
         sheetsMock.push(membersTableSheetMock);
@@ -112,28 +113,28 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         loadMembersFromOnestopIntoScriptProperties();
 
         const expectedMemberMap: MemberMap = {
-            memberName1: {name: "memberName1", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
-            memberName2: {name: "memberName2", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
-            memberName3: {name: "memberName3", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
-            memberName4: {name: "memberName4", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
-            memberName5: {name: "memberName5", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
+            "John Doe": {name: "John Doe", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
+            "James Brown": {name: "James Brown", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
+            "Mary Brown": {name: "Mary Brown", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
+            "Robert White": {name: "Robert White", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
+            "Emily White": {name: "Emily White", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
         };
 
         const expectedAliasMap: AliasMap = {
-            alias1: ["memberName1"],
-            alias2: ["memberName1"],
-            alias3: ["memberName2"],
-            alias4: ["memberName2"],
-            alias5: ["memberName3"],
-            alias6: ["memberName3"],
-            alias7: ["memberName4"],
-            alias8: ["memberName4"],
-            alias9: ["memberName5"],
-            alias10: ["memberName5"],
-            coupleAlias1: ["memberName2", "memberName3"],
-            coupleAlias2: ["memberName2", "memberName3"],
-            coupleAlias3: ["memberName4", "memberName5"],
-            coupleAlias4: ["memberName4", "memberName5"],
+            "John": ["John Doe"],
+            "John D": ["John Doe"],
+            "James": ["James Brown"],
+            "James B": ["James Brown"],
+            "Mary": ["Mary Brown"],
+            "Mary B": ["Mary Brown"],
+            "Robert": ["Robert White"],
+            "Robert W": ["Robert White"],
+            "Emily": ["Emily White"],
+            "Emily W": ["Emily White"],
+            "James/Mary": ["James Brown", "Mary Brown"],
+            "Browns": ["James Brown", "Mary Brown"],
+            "Robert/Emily": ["Robert White", "Emily White"],
+            "Whites": ["Robert White", "Emily White"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledTimes(2);
@@ -212,10 +213,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersTableSheetMock.getName = jest.fn(() => "Members");
         membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
 
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "name1";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "name2";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
         const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
@@ -241,10 +242,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         loadMembersFromOnestopIntoScriptProperties();
 
         const expected: AliasMap = {
-            alias1: ["name1"],
-            alias2: ["name1"],
-            alias3: ["name2"],
-            alias4: ["name2"],
+            "John": ["John Doe"],
+            "John D": ["John Doe"],
+            "James": ["James Brown"],
+            "James B": ["James Brown"],
         };
         expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
     });
@@ -257,10 +258,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersTableSheetMock.getName = jest.fn(() => "Members");
         membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
 
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "name1";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "name2";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias2,alias3";
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "John Brown";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
         const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
@@ -286,9 +287,9 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         loadMembersFromOnestopIntoScriptProperties();
 
         const expected: AliasMap = {
-            alias1: ["name1"],
-            alias2: ["name1", "name2"],
-            alias3: ["name2"],
+            "John": ["John Doe", "John Brown"],
+            "John D": ["John Doe"],
+            "John B": ["John Brown"],
         };
         expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
     });
@@ -301,12 +302,12 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersTableSheetMock.getName = jest.fn(() => "Members");
         membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
 
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "memberName";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "alias1,alias2";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "husbandName";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "alias3,alias4";
-        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "wifeName";
-        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "alias5,alias6";
+        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Miller";
+        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John M, JM";
+        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "Mary Brown";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(1);
         const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
@@ -315,7 +316,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesTableSheetMock.getName = jest.fn(() => "Couples");
         couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
-        couplesDataValuesMock[1] = ["husbandName", "wifeName", "alias1"];
+        couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "JM"];
 
         const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
         sheetsMock.push(membersTableSheetMock);
@@ -334,12 +335,13 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         loadMembersFromOnestopIntoScriptProperties();
 
         const expected: AliasMap = {
-            alias1: ["memberName", "husbandName", "wifeName"],
-            alias2: ["memberName"],
-            alias3: ["husbandName"],
-            alias4: ["husbandName"],
-            alias5: ["wifeName"],
-            alias6: ["wifeName"],
+            "John": ["John Miller"],
+            "John M": ["John Miller"],
+            "JM": ["John Miller", "James Brown", "Mary Brown"],
+            "James": ["James Brown"],
+            "James B": ["James Brown"],
+            "Mary": ["Mary Brown"],
+            "Mary B": ["Mary Brown"]
         };
         expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(expected));
     });

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -218,6 +218,191 @@ export function getRandomlyGeneratedRange(): Range {
     };
 }
 
+export function getRandomlyGeneratedMember(): Member {
+    return {
+        name: randomstring.generate(),
+        gender: randomstring.generate(),
+        married: getRandomBoolean(),
+        parent: getRandomBoolean(),
+        class: getRandomNumber(),
+    };
+}
+
+export function getRandomlyGeneratedMemberMap(numMembers: number = 10): MemberMap {
+    const memberMap: MemberMap = {};
+    for(let i = 0; i < numMembers; i++) {
+        const member: Member = getRandomlyGeneratedMember();
+        memberMap[member.name] = member;
+    }
+
+    return memberMap;
+}
+
+function getRandomlyGeneratedMemberRow(numAlternateNames: number = 3): any[] {
+    return [randomstring.generate(), randomstring.generate(), getRandomBoolean(), getRandomBoolean(), getRandomNumber(), Array.from({length: numAlternateNames}, () => randomstring.generate()).join(",")];
+}
+
+export function getRandomlyGeneratedMemberTable(numMembers: number = 10, numAlternateNames: number = 3): any[][] {
+    const memberTable: any[][] = [["Name", "Gender", "Married", "Parent", "Class", "Alertnate Names (comma separated)"]];
+    for(let i = 0; i < numMembers; i++) {
+        memberTable.push(getRandomlyGeneratedMemberRow(numAlternateNames));
+    }
+
+    return memberTable;
+}
+
+export function getRandomlyGeneratedAliasMap(numAliases: number = 10): AliasMap {
+    const aliasMap: AliasMap = {};
+    for(let i = 0; i < numAliases; i++) {
+        const members: string[] = Array.from({length: numAliases}, () => randomstring.generate());
+        aliasMap[randomstring.generate()] = members;
+    }
+    
+    return aliasMap;
+}
+
+function getRandomlyGeneratedAliasRow(numAliases: number = 3): any[] {
+    return [randomstring.generate(), randomstring.generate(), Array.from({length: numAliases}, () => randomstring.generate()).join(",")];
+}
+
+export function getRandomlyGeneratedAliasTable(numCoupleAliases: number = 10): any[][] {
+    const aliasTable: any[][] = [["Husband", "Wife", "Couple Aliases"]];
+    for(let i = 0; i < numCoupleAliases; i++) {
+        aliasTable.push(getRandomlyGeneratedAliasRow());
+    }
+
+    return aliasTable;
+}
+
+export function getRandomlyGeneratedSheet(): Sheet {
+    return {
+        activate: jest.fn().mockReturnThis(),
+        addDeveloperMetadata: jest.fn().mockReturnThis(),
+        appendRow: jest.fn().mockReturnThis(),
+        asDataSourceSheet: jest.fn().mockReturnValue(null),
+        autoResizeColumn: jest.fn().mockReturnThis(),
+        autoResizeColumns: jest.fn().mockReturnThis(),
+        autoResizeRows: jest.fn().mockReturnThis(),
+        clear: jest.fn().mockReturnThis(),
+        clearConditionalFormatRules: jest.fn(),
+        clearContents: jest.fn().mockReturnThis(),
+        clearFormats: jest.fn().mockReturnThis(),
+        clearNotes: jest.fn().mockReturnThis(),
+        collapseAllColumnGroups: jest.fn().mockReturnThis(),
+        collapseAllRowGroups: jest.fn().mockReturnThis(),
+        copyTo: jest.fn().mockReturnThis(),
+        createDeveloperMetadataFinder: jest.fn(),
+        createTextFinder: jest.fn(),
+        deleteColumn: jest.fn().mockReturnThis(),
+        deleteColumns: jest.fn(),
+        deleteRow: jest.fn().mockReturnThis(),
+        deleteRows: jest.fn(),
+        expandAllColumnGroups: jest.fn().mockReturnThis(),
+        expandAllRowGroups: jest.fn().mockReturnThis(),
+        expandColumnGroupsUpToDepth: jest.fn().mockReturnThis(),
+        expandRowGroupsUpToDepth: jest.fn().mockReturnThis(),
+        getActiveCell: jest.fn(),
+        getActiveRange: jest.fn(),
+        getActiveRangeList: jest.fn(),
+        getBandings: jest.fn().mockReturnValue([]),
+        getCharts: jest.fn().mockReturnValue([]),
+        getColumnGroup: jest.fn(),
+        getColumnGroupControlPosition: jest.fn(),
+        getColumnGroupDepth: jest.fn().mockReturnValue(0),
+        getColumnWidth: jest.fn().mockReturnValue(0),
+        getConditionalFormatRules: jest.fn().mockReturnValue([]),
+        getCurrentCell: jest.fn(),
+        getDataRange: jest.fn(),
+        getDataSourceTables: jest.fn().mockReturnValue([]),
+        getDeveloperMetadata: jest.fn().mockReturnValue([]),
+        getDrawings: jest.fn().mockReturnValue([]),
+        getFilter: jest.fn(),
+        getFormUrl: jest.fn(),
+        getFrozenColumns: jest.fn().mockReturnValue(0),
+        getFrozenRows: jest.fn().mockReturnValue(0),
+        getImages: jest.fn().mockReturnValue([]),
+        getIndex: jest.fn().mockReturnValue(0),
+        getLastColumn: jest.fn().mockReturnValue(0),
+        getLastRow: jest.fn().mockReturnValue(0),
+        getMaxColumns: jest.fn().mockReturnValue(0),
+        getMaxRows: jest.fn().mockReturnValue(0),
+        getName: jest.fn().mockReturnValue(randomstring.generate()),
+        getNamedRanges: jest.fn().mockReturnValue([]),
+        getParent: jest.fn(),
+        getPivotTables: jest.fn().mockReturnValue([]),
+        getProtections: jest.fn().mockReturnValue([]),
+        getRange: jest.fn(),
+        getRangeList: jest.fn(),
+        getRowGroup: jest.fn(),
+        getRowGroupControlPosition: jest.fn(),
+        getRowGroupDepth: jest.fn().mockReturnValue(0),
+        getRowHeight: jest.fn().mockReturnValue(0),
+        getSelection: jest.fn(),
+        getSheetId: jest.fn().mockReturnValue(0),
+        getSheetName: jest.fn().mockReturnValue(randomstring.generate()),
+        getSheetValues: jest.fn().mockReturnValue([]),
+        getSlicers: jest.fn().mockReturnValue([]),
+        getTabColor: jest.fn(),
+        getType: jest.fn(),
+        hasHiddenGridlines: jest.fn().mockReturnValue(getRandomBoolean()),
+        hideColumn: jest.fn(),
+        hideColumns: jest.fn(),
+        hideRow: jest.fn(),
+        hideRows: jest.fn(),
+        hideSheet: jest.fn().mockReturnThis(),
+        insertChart: jest.fn(),
+        insertColumnAfter: jest.fn().mockReturnThis(),
+        insertColumnBefore: jest.fn().mockReturnThis(),
+        insertColumns: jest.fn(),
+        insertColumnsAfter: jest.fn().mockReturnThis(),
+        insertColumnsBefore: jest.fn().mockReturnThis(),
+        insertImage: jest.fn(),
+        insertRowAfter: jest.fn().mockReturnThis(),
+        insertRowBefore: jest.fn().mockReturnThis(),
+        insertRows: jest.fn(),
+        insertRowsAfter: jest.fn().mockReturnThis(),
+        insertRowsBefore: jest.fn().mockReturnThis(),
+        insertSlicer: jest.fn(),
+        isColumnHiddenByUser: jest.fn().mockReturnValue(getRandomBoolean()),
+        isRightToLeft: jest.fn().mockReturnValue(getRandomBoolean()),
+        isRowHiddenByFilter: jest.fn().mockReturnValue(getRandomBoolean()),
+        isRowHiddenByUser: jest.fn().mockReturnValue(getRandomBoolean()),
+        isSheetHidden: jest.fn().mockReturnValue(getRandomBoolean()),
+        moveColumns: jest.fn(),
+        moveRows: jest.fn(),
+        newChart: jest.fn(),
+        protect: jest.fn(),
+        removeChart: jest.fn(),
+        setActiveRange: jest.fn(),
+        setActiveRangeList: jest.fn(),
+        setActiveSelection: jest.fn(),
+        setColumnGroupControlPosition: jest.fn(),
+        setColumnWidth: jest.fn().mockReturnThis(),
+        setColumnWidths: jest.fn().mockReturnThis(),
+        setConditionalFormatRules: jest.fn(),
+        setCurrentCell: jest.fn(),
+        setFrozenColumns: jest.fn(),
+        setFrozenRows: jest.fn(),
+        setHiddenGridlines: jest.fn(),
+        setName: jest.fn(),
+        setRightToLeft: jest.fn(),
+        setRowGroupControlPosition: jest.fn(),
+        setRowHeight: jest.fn().mockReturnThis(),
+        setRowHeights: jest.fn().mockReturnThis(),
+        setRowHeightsForced: jest.fn().mockReturnThis(),
+        setTabColor: jest.fn(),
+        showColumns: jest.fn(),
+        showRows: jest.fn(),
+        showSheet: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        unhideColumn: jest.fn(),
+        unhideRow: jest.fn(),
+        updateChart: jest.fn(),
+        getSheetProtection: jest.fn(),
+        setSheetProtection: jest.fn(),
+    };
+}
+
 function getRandomlyGeneratedText(): Text {
     return {
         value: randomstring.generate(),

--- a/jest.config.js
+++ b/jest.config.js
@@ -113,7 +113,7 @@ const config = {
   // resetMocks: false,
 
   // Reset the module registry before running each individual test
-  // resetModules: false,
+  resetModules: true,
 
   // A path to a custom resolver
   // resolver: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { onOpen } from './main/menu';
 
 export * from './main/basecamp';
 export * from './main/main';
+export * from './main/members';
 export * from './main/people';
 export * from './main/propertiesService';
 export * from './main/row';

--- a/src/main/error/tabNotFoundError.ts
+++ b/src/main/error/tabNotFoundError.ts
@@ -1,0 +1,9 @@
+export class TabNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TabNotFoundError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, TabNotFoundError.prototype);
+    }
+}

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -24,8 +24,7 @@ export const ALIASES_MAP: AliasMap = loadMapFromScriptProperties(ALIASES_MAP_KEY
 export function loadMembersFromOnestopIntoScriptProperties(): void {
     const { memberMap: memberMap, alternateNamesMap: alternateNamesMap } = loadMembersFromOnestop();
     const coupleAliases: AliasMap = loadCouplesFromOnestop();
-    // Assumes there will never be overlap between alternate names and couple aliases (there shouldn't be)
-    const combinedAliases: AliasMap = { ...alternateNamesMap, ...coupleAliases };
+    const combinedAliases: AliasMap = mergeAliasMaps(alternateNamesMap, coupleAliases);
 
     setScriptProperty(MEMBER_MAP_KEY, JSON.stringify(memberMap));
     setScriptProperty(ALIASES_MAP_KEY, JSON.stringify(combinedAliases));
@@ -104,6 +103,21 @@ function loadCouplesFromOnestop(): AliasMap {
     }
 
     return aliasMap;
+}
+
+function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap): AliasMap {
+    const finalAliasMap: AliasMap = firstAliasMap;
+
+    const aliases: string[] = Object.keys(secondAliasMap);
+    for(const alias of aliases) {
+        if(finalAliasMap.hasOwnProperty(alias)) {
+            finalAliasMap[alias].concat(secondAliasMap[alias]);
+        } else {
+            finalAliasMap[alias] = secondAliasMap[alias];
+        }
+    }
+
+    return finalAliasMap;
 }
 
 function loadMapFromScriptProperties(key: string): Object {

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -6,8 +6,8 @@ const MEMBERS_TAB_NAME: string = "Members";
 const COUPLES_TAB_NAME: string = "Couples";
 const NAME_COLUMN_INDEX: number = 0;
 const GENDER_COLUMN_INDEX: number = 1;
-const PARENT_COLUMN_INDEX: number = 2;
-const SPOUSE_COLUMN_INDEX: number = 3;
+const MARRIED_COLUMN_INDEX: number = 2;
+const PARENT_COLUMN_INDEX: number = 3;
 const CLASS_COLUMN_INDEX: number = 4;
 const ALTERNATE_NAMES_COLUMN_INDEX: number = 5;
 const HUSBAND_COLUMN_INDEX: number = 0;
@@ -76,7 +76,7 @@ function constructMember(rowValues: any): Member {
         name: rowValues[NAME_COLUMN_INDEX],
         gender: rowValues[GENDER_COLUMN_INDEX],
         parent: rowValues[PARENT_COLUMN_INDEX],
-        spouse: rowValues[SPOUSE_COLUMN_INDEX] !== "" ? rowValues[SPOUSE_COLUMN_INDEX] : undefined,
+        married: rowValues[MARRIED_COLUMN_INDEX],
         class: rowValues[CLASS_COLUMN_INDEX]
     };
 }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -74,8 +74,8 @@ function constructMember(rowValues: any): Member {
     return {
         name: rowValues[NAME_COLUMN_INDEX],
         gender: rowValues[GENDER_COLUMN_INDEX],
-        parent: rowValues[PARENT_COLUMN_INDEX],
         married: rowValues[MARRIED_COLUMN_INDEX],
+        parent: rowValues[PARENT_COLUMN_INDEX],
         class: rowValues[CLASS_COLUMN_INDEX]
     };
 }
@@ -111,7 +111,7 @@ function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap): Alia
     const aliases: string[] = Object.keys(secondAliasMap);
     for(const alias of aliases) {
         if(finalAliasMap.hasOwnProperty(alias)) {
-            finalAliasMap[alias].concat(secondAliasMap[alias]);
+            finalAliasMap[alias] = finalAliasMap[alias].concat(secondAliasMap[alias]);
         } else {
             finalAliasMap[alias] = secondAliasMap[alias];
         }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -1,0 +1,112 @@
+import { TabNotFoundError } from "./error/tabNotFoundError";
+import { getScriptProperty, setScriptProperty } from "./propertiesService";
+import { getAllSpreadsheetTabs } from "./scan";
+
+const MEMBERS_TAB_NAME: string = "Members";
+const COUPLES_TAB_NAME: string = "Couples";
+const NAME_COLUMN_INDEX: number = 0;
+const GENDER_COLUMN_INDEX: number = 1;
+const PARENT_COLUMN_INDEX: number = 2;
+const SPOUSE_COLUMN_INDEX: number = 3;
+const CLASS_COLUMN_INDEX: number = 4;
+const ALTERNATE_NAMES_COLUMN_INDEX: number = 5;
+const HUSBAND_COLUMN_INDEX: number = 0;
+const WIFE_COLUMN_INDEX: number = 1;
+const COUPLES_ALIASES_COLUMN_INDEX: number = 2;
+const COMMA_DELIMITER: string = ",";
+const MEMBER_MAP_KEY: string = "MEMBER_MAP";
+const ALIASES_MAP_KEY: string = "ALIASES_MAP";
+
+
+export const MEMBER_MAP: MemberMap = loadMapFromScriptProperties(MEMBER_MAP_KEY) as MemberMap;
+export const ALIASES_MAP: AliasMap = loadMapFromScriptProperties(ALIASES_MAP_KEY) as AliasMap;
+
+export function loadMembersFromOnestopIntoScriptProperties(): void {
+    const { memberMap: memberMap, alternateNamesMap: alternateNamesMap } = loadMembersFromOnestop();
+    const coupleAliases: AliasMap = loadCouplesFromOnestop();
+    // Assumes there will never be overlap between alternate names and couple aliases (there shouldn't be)
+    const combinedAliases: AliasMap = { ...alternateNamesMap, ...coupleAliases };
+
+    setScriptProperty(MEMBER_MAP_KEY, JSON.stringify(memberMap));
+    setScriptProperty(ALIASES_MAP_KEY, JSON.stringify(combinedAliases));
+}
+
+function getTab(tabName: string): Sheet {
+    const tabs: Sheet[] = getAllSpreadsheetTabs();
+    for(const tab of tabs) {
+        const currentTabName: string = tab.getName();
+        if(currentTabName === tabName) {
+            return tab;
+        }
+    }
+
+    throw new TabNotFoundError(`No ${tabName} tab found`);
+}
+
+function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: AliasMap } {
+    const membersTab: Sheet = getTab(MEMBERS_TAB_NAME);
+    const dataRange: Range = membersTab.getDataRange();
+    const cellValues: any[][] = dataRange.getValues();
+
+    const memberMap: MemberMap = {};
+    const alternateNamesMap: AliasMap = {};
+
+    // Start at row 1 to skip the table header row
+    for(let i = 1; i < cellValues.length; i++) {
+        const rowValues: any[] = cellValues[i];
+        const currentMember: Member = constructMember(rowValues);
+        memberMap[currentMember.name] = currentMember;
+
+        const alternateNames: string[] = getAliasList(rowValues, ALTERNATE_NAMES_COLUMN_INDEX);
+        // Maps a person's alternate name to their actual name
+        alternateNames.forEach(alternateName => {
+            if(alternateNamesMap.hasOwnProperty(alternateName)) {
+                alternateNamesMap[alternateName].push(currentMember.name);
+            } else {
+                alternateNamesMap[alternateName] = [currentMember.name];
+            }
+        });
+    }
+
+    return { memberMap: memberMap, alternateNamesMap: alternateNamesMap };
+}
+
+function constructMember(rowValues: any): Member {
+    return {
+        name: rowValues[NAME_COLUMN_INDEX],
+        gender: rowValues[GENDER_COLUMN_INDEX],
+        parent: rowValues[PARENT_COLUMN_INDEX],
+        spouse: rowValues[SPOUSE_COLUMN_INDEX] !== "" ? rowValues[SPOUSE_COLUMN_INDEX] : undefined,
+        class: rowValues[CLASS_COLUMN_INDEX]
+    };
+}
+
+function getAliasList(rowValues: any, index: number): string[] {
+    const aliasList: string = rowValues[index];
+    return aliasList.split(COMMA_DELIMITER).map(alias => alias.trim());
+}
+
+function loadCouplesFromOnestop(): AliasMap {
+    const couplesTab: Sheet = getTab(COUPLES_TAB_NAME);
+    const dataRange: Range = couplesTab.getDataRange();
+    const cellValues: any[][] = dataRange.getValues();
+
+    const aliasMap: AliasMap = {};
+
+    // Start at row 1 to skip the table header row
+    for(let i = 1; i < cellValues.length; i++) {
+        const rowValues: any[] = cellValues[i];
+
+        const coupleAliasesList: string[] = getAliasList(rowValues, COUPLES_ALIASES_COLUMN_INDEX);
+        const husband: string = rowValues[HUSBAND_COLUMN_INDEX];
+        const wife: string = rowValues[WIFE_COLUMN_INDEX];
+        coupleAliasesList.forEach(coupleAlias => aliasMap[coupleAlias] = [husband, wife]);
+    }
+
+    return aliasMap;
+}
+
+function loadMapFromScriptProperties(key: string): Object {
+    const map: string | null = getScriptProperty(key);
+    return map ? JSON.parse(map) : {};
+}

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -102,8 +102,8 @@ type RoleRequestMap = { [key: string]: BasecampTodoRequest }
 declare interface Member {
   name: string,
   gender: string,
-  parent: boolean,
   married: boolean,
+  parent: boolean,
   class: number
 }
 

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -103,7 +103,7 @@ declare interface Member {
   name: string,
   gender: string,
   parent: boolean,
-  spouse?: string
+  married: boolean,
   class: number
 }
 

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -98,3 +98,17 @@ declare interface Person extends JsonObject {
 type DocumentProperties = { [key: string]: RowBasecampMapping };
 
 type RoleRequestMap = { [key: string]: BasecampTodoRequest }
+
+declare interface Member {
+  name: string,
+  gender: string,
+  parent: boolean,
+  spouse?: string
+  class: number
+}
+
+// Maps a members name to their Member object containing their properties
+type MemberMap = { [key: string]: Member };
+
+// Maps an alias to an array of member names that the alias corresponds to
+type AliasMap = { [key: string]: string[] };


### PR DESCRIPTION
This PR adds logic to load a members and couples table from the Onestop into the script properties. The table is expected to be on the `Members` and `Couples` tabs respectively and should be of the following formats
<img width="856" alt="Screenshot 2024-11-14 at 6 37 19 PM" src="https://github.com/user-attachments/assets/1ef2ac3d-e111-4304-8086-848e36a1a4da">
<img width="425" alt="Screenshot 2024-11-14 at 6 39 10 PM" src="https://github.com/user-attachments/assets/450142f8-f3a1-4f40-8282-ff1044919aa5">
The logic read these tables and load 2 maps into script properties: 
1. A MEMBER_MAP which maps a members name to their properties (ex. Josh Wong -> {name: Josh Wong, gender: Male, married: false, parent: false, class: 2022}
3. An ALIAS_MAP which maps an alias to an array of member names the alias refers to. This alias can be either a couple's alias or a person's alternate name (ex. Josh W. -> [Josh Wong] or Andrew/Janice -> [Andrew Chan, Janice Chan] )

Test coverage:
<img width="1717" alt="Screenshot 2024-11-14 at 6 37 04 PM" src="https://github.com/user-attachments/assets/c4bfa3c5-665b-4859-a585-af2e88fe1074">
In order to have different mocks for each test because each test may have different mocking requirements, the function/module under test has to be loaded/imported dynamically with `require` after all mocks for the test are setup. If the function under test is imported at the top of the file, it will be imported without any of the mocks for the current test being set which is not what we want