### PR TITLE
WIP - Added Group and Supergroup loading

### DIFF
--- a/__test__/groups.test.ts
+++ b/__test__/groups.test.ts
@@ -1,0 +1,480 @@
+import { Logger } from "gasmask";
+global.Logger = Logger;
+
+import { getRandomlyGeneratedGroupsMap, getRandomlyGeneratedGroupsTable, getRandomlyGeneratedSupergroupsTable, Mock } from "./testUtils";
+
+const GROUP_NAME_COLUMN_INDEX: number = 0;
+const GROUP_MEMBERS_COLUMN_INDEX: number = 1;
+const SUPERGROUP_NAME_COLUMN_INDEX: number = 0;
+const SUPERGROUP_SUBGROUP_COLUMN_INDEX: number = 1;
+
+describe("GROUPS_MAP", () => {
+    it("should return the groups map from the script properties when it is present", () => {
+        const groupsMapMock: GroupsMap = getRandomlyGeneratedGroupsMap();
+
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => groupsMapMock),
+        }));
+        
+        // Import the GROUPS_MAP with the mocked propertiesService
+        const { GROUPS_MAP } = require('../src/main/groups');
+
+        expect(GROUPS_MAP).toEqual(groupsMapMock);
+    });
+
+    it("should return an empty map when there is no groups map present in the script properties", () => {
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+        }));
+
+        // Import the GROUPS_MAP with the mocked propertiesService
+        const { GROUPS_MAP } = require('../src/main/groups');
+
+        expect(GROUPS_MAP).toStrictEqual({});
+    });
+});
+
+describe("loadGroupsFromOnestopIntoScriptProperties", () => {
+    it("should load a mapping of group name to a list of group members when the Groups table is present and not empty", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(3);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(0);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "IGSM";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "IUSM";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            IGSM: ["John Doe", "Jane Smith"],
+            A2K: ["Alice Johnson", "Bob Brown"],
+            IUSM: ["Charlie Davis", "Emily Clark"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should load an empty object into script properties when the Groups table is empty", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(0);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(0);
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", "{}");
+    });
+
+    it("should load an empty list for a group's members when no members are specified", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(1);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(0);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "IGSM";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            IGSM: []
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should combine multiple entries of the same group when a group is accidentally defined more than once in the Groups table", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(3);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(0);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "IGSM";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "IGSM";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark, Jane Smith";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            IGSM: ["John Doe", "Jane Smith", "Charlie Davis", "Emily Clark"],
+            A2K: ["Alice Johnson", "Bob Brown"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should load all Supergroups into script properties when there are no dependencies on groups that have not been loaded yet", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
+            Community: ["Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should skip loading a Supergroup when its dependent subgroups have not all been loaded", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(2);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(2);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            Community: ["Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should skip empty Supergroup table rows when Google Sheets returns more rows than the table because of extra data on the spreadsheet", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            Community: ["Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should load all Supergroups into script properties when there are dependencies on groups that have not been loaded yet", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            Community: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should merge the menmbers of a Supergroup and a group when a Supergroup and a group have the same name (should never happen)", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson", "Charlie Davis", "Emily Clark"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should load an empty list for a Supergroup when the Supergroup does not have any subgroups defined", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            College: [],
+            Community: ["Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should remove duplicate members when members are part of multiple subgroups within the same Supergroup", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith, Charlie Davis";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "IUSM";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "IGSM";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "Everyone";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, International";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "International";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "IUSM, IGSM";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith", "Charlie Davis"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            IUSM: ["Charlie Davis", "Emily Clark"],
+            IGSM: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown"],
+            International: ["Charlie Davis", "Emily Clark", "Frank Miller", "Grace Wilson"],
+            Everyone: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown", "Emily Clark", "Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+});

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -5,7 +5,6 @@ global.PropertiesService = PropertiesService;
 global.SpreadsheetApp = SpreadsheetApp;
 
 import { getRandomlyGeneratedAliasMap, getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, getRandomlyGeneratedRange, getRandomlyGeneratedSheet, Mock } from './testUtils';
-import { TabNotFoundError } from '../src/main/error/tabNotFoundError';
 
 const NAME_COLUMN_INDEX: number = 0;
 const GENDER_COLUMN_INDEX: number = 1;
@@ -96,11 +95,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "James/Mary,Browns"];
         couplesDataValuesMock[2] = ["Robert White", "Emily White", "Robert/Emily,Whites"];
 
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        sheetsMock.push(couplesTableSheetMock);
         jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+            getTab: jest.fn()
+            .mockReturnValueOnce(membersTableSheetMock)
+            .mockReturnValueOnce(couplesTableSheetMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -142,35 +140,6 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         expect(setScriptPropertyMock).toHaveBeenNthCalledWith(2, "ALIASES_MAP", JSON.stringify(expectedAliasMap));
     });
 
-    it("should throw a TabNotFoundError error when the Members tab does not exist on the onestop", () => {
-        jest.doMock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => Array.from({length: 10}, getRandomlyGeneratedSheet)),
-        }));
-
-        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
-
-        expect(() => loadMembersFromOnestopIntoScriptProperties()).toThrow(new TabNotFoundError("No Members tab found"));
-    });
-
-    it("should throw a TabNotFoundError error when the Couples tab does not exist on the onestop", () => {
-        const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable();
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
-
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
-        }));
-
-        const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
-
-        expect(() => loadMembersFromOnestopIntoScriptProperties()).toThrow(new TabNotFoundError("No Couples tab found"));
-    });
-
     it("should load an empty object into script properties for the members map when the members table is empty", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(0);
         const membersDataRangeMock: Range = getRandomlyGeneratedRange();
@@ -186,11 +155,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesTableSheetMock.getName = jest.fn(() => "Couples");
         couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        sheetsMock.push(couplesTableSheetMock);
         jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+            getTab: jest.fn()
+            .mockReturnValueOnce(membersTableSheetMock)
+            .mockReturnValueOnce(couplesTableSheetMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -225,11 +193,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesTableSheetMock.getName = jest.fn(() => "Couples");
         couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        sheetsMock.push(couplesTableSheetMock);
         jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+            getTab: jest.fn()
+            .mockReturnValueOnce(membersTableSheetMock)
+            .mockReturnValueOnce(couplesTableSheetMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -270,11 +237,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesTableSheetMock.getName = jest.fn(() => "Couples");
         couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        sheetsMock.push(couplesTableSheetMock);
         jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+            getTab: jest.fn()
+            .mockReturnValueOnce(membersTableSheetMock)
+            .mockReturnValueOnce(couplesTableSheetMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -318,11 +284,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "JM"];
 
-        const sheetsMock: Sheet[] = Array.from({length: 10}, getRandomlyGeneratedSheet);
-        sheetsMock.push(membersTableSheetMock);
-        sheetsMock.push(couplesTableSheetMock);
         jest.mock("../src/main/scan", () => ({
-            getAllSpreadsheetTabs: jest.fn(() => sheetsMock),
+            getTab: jest.fn()
+            .mockReturnValueOnce(membersTableSheetMock)
+            .mockReturnValueOnce(couplesTableSheetMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -4,7 +4,7 @@ global.Logger = Logger;
 global.PropertiesService = PropertiesService;
 global.SpreadsheetApp = SpreadsheetApp;
 
-import { getRandomlyGeneratedAliasMap, getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, getRandomlyGeneratedRange, getRandomlyGeneratedSheet, Mock } from './testUtils';
+import { getRandomlyGeneratedAliasMap, getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, Mock } from './testUtils';
 
 const NAME_COLUMN_INDEX: number = 0;
 const GENDER_COLUMN_INDEX: number = 1;

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -18,8 +18,8 @@ describe("MEMBER_MAP", () => {
     it("should return the member map from the script properties when it is present", () => {
         const memberMapMock: MemberMap = getRandomlyGeneratedMemberMap();
 
-        jest.doMock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(() => JSON.stringify(memberMapMock)),
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => memberMapMock),
         }));
         
         // Import the MEMBER_MAP with the mocked propertiesService
@@ -29,8 +29,8 @@ describe("MEMBER_MAP", () => {
     });
 
     it("should return an empty map when there is no member map present in the script properties", () => {
-        jest.doMock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(() => null),
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
         }));
 
         // Import the MEMBER_MAP with the mocked propertiesService
@@ -44,8 +44,8 @@ describe("ALIASES_MAP", () => {
     it("should return the aliases map from the script properties when it is present", () => {
         const aliasesMapMock: AliasMap = getRandomlyGeneratedAliasMap();
 
-        jest.doMock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(() => JSON.stringify(aliasesMapMock)),
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => aliasesMapMock),
         }));
         
         // Import the MEMBER_MAP with the mocked propertiesService
@@ -55,8 +55,8 @@ describe("ALIASES_MAP", () => {
     });
 
     it("should return an empty map when there is no aliases map present in the script properties", () => {
-        jest.doMock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(() => null),
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
         }));
 
         // Import the MEMBER_MAP with the mocked propertiesService
@@ -105,7 +105,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         const setScriptPropertyMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(),
             setScriptProperty: setScriptPropertyMock,
         }));
 
@@ -195,7 +195,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         const setScriptPropertyMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(),
             setScriptProperty: setScriptPropertyMock,
         }));
 
@@ -234,7 +234,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         const setScriptPropertyMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(),
             setScriptProperty: setScriptPropertyMock,
         }));
 
@@ -279,7 +279,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         const setScriptPropertyMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(),
             setScriptProperty: setScriptPropertyMock,
         }));
 
@@ -327,7 +327,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
         const setScriptPropertyMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
-            getScriptProperty: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(),
             setScriptProperty: setScriptPropertyMock,
         }));
 

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -68,12 +68,6 @@ describe("ALIASES_MAP", () => {
 describe("loadMembersFromOnestopIntoScriptProperties", () => {
     it("should load the members and couples table from the onestop into the script properties when the members and couples table are present on the onestop", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(5, 1);
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
-
         membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
         membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
         membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
@@ -86,19 +80,13 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "Emily,Emily W";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(2);
-        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
-        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
-        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        couplesTableSheetMock.getName = jest.fn(() => "Couples");
-        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
-
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "James/Mary,Browns"];
         couplesDataValuesMock[2] = ["Robert White", "Emily White", "Robert/Emily,Whites"];
 
         jest.mock("../src/main/scan", () => ({
-            getTab: jest.fn()
-            .mockReturnValueOnce(membersTableSheetMock)
-            .mockReturnValueOnce(couplesTableSheetMock),
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(membersDataValuesMock)
+            .mockReturnValueOnce(couplesDataValuesMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -142,23 +130,12 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should load an empty object into script properties for the members map when the members table is empty", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(0);
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
-
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(3);
-        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
-        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
-        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        couplesTableSheetMock.getName = jest.fn(() => "Couples");
-        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
         jest.mock("../src/main/scan", () => ({
-            getTab: jest.fn()
-            .mockReturnValueOnce(membersTableSheetMock)
-            .mockReturnValueOnce(couplesTableSheetMock),
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(membersDataValuesMock)
+            .mockReturnValueOnce(couplesDataValuesMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -175,28 +152,17 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should load a object of just the member alternate names when the couples table is empty", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
-
         membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
         membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
         membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
         membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
-        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
-        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
-        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        couplesTableSheetMock.getName = jest.fn(() => "Couples");
-        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
         jest.mock("../src/main/scan", () => ({
-            getTab: jest.fn()
-            .mockReturnValueOnce(membersTableSheetMock)
-            .mockReturnValueOnce(couplesTableSheetMock),
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(membersDataValuesMock)
+            .mockReturnValueOnce(couplesDataValuesMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -219,28 +185,17 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should map an alternate name to multiple people when multiple people share the same alternate name", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
-
         membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
         membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
         membersDataValuesMock[2][NAME_COLUMN_INDEX] = "John Brown";
         membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
-        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
-        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
-        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        couplesTableSheetMock.getName = jest.fn(() => "Couples");
-        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
 
         jest.mock("../src/main/scan", () => ({
-            getTab: jest.fn()
-            .mockReturnValueOnce(membersTableSheetMock)
-            .mockReturnValueOnce(couplesTableSheetMock),
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(membersDataValuesMock)
+            .mockReturnValueOnce(couplesDataValuesMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();
@@ -262,11 +217,6 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should map an alias to both a person and a couple when a person's alternate name is the same as a couple's alias", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(3, 1);
-        const membersDataRangeMock: Range = getRandomlyGeneratedRange();
-        membersDataRangeMock.getValues = jest.fn(() => membersDataValuesMock);
-        const membersTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        membersTableSheetMock.getName = jest.fn(() => "Members");
-        membersTableSheetMock.getDataRange = jest.fn(() => membersDataRangeMock);
 
         membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Miller";
         membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John M, JM";
@@ -276,18 +226,12 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(1);
-        const couplesDataRangeMock: Range = getRandomlyGeneratedRange();
-        couplesDataRangeMock.getValues = jest.fn(() => couplesDataValuesMock);
-        const couplesTableSheetMock: Sheet = getRandomlyGeneratedSheet();
-        couplesTableSheetMock.getName = jest.fn(() => "Couples");
-        couplesTableSheetMock.getDataRange = jest.fn(() => couplesDataRangeMock);
-
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "JM"];
 
         jest.mock("../src/main/scan", () => ({
-            getTab: jest.fn()
-            .mockReturnValueOnce(membersTableSheetMock)
-            .mockReturnValueOnce(couplesTableSheetMock),
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(membersDataValuesMock)
+            .mockReturnValueOnce(couplesDataValuesMock),
         }));
 
         const setScriptPropertyMock: Mock = jest.fn();

--- a/__test__/propertiesService.test.ts
+++ b/__test__/propertiesService.test.ts
@@ -1,0 +1,31 @@
+import { PropertiesService } from "gasmask";
+import Properties from "gasmask/dist/Properties";
+import { getRandomlyGeneratedGroupsMap } from "./testUtils";
+global.PropertiesService = PropertiesService;
+
+describe("loadMapFromScriptProperties", () => {
+    it("should return an empty object when the requested map key cannot be found in the script properties", () => {
+        const scriptPropertiesMock: Properties = new Properties();
+
+        jest.spyOn(scriptPropertiesMock, "getProperty").mockReturnValue(null);
+        jest.spyOn(PropertiesService, "getScriptProperties").mockReturnValue(scriptPropertiesMock);
+
+        const { loadMapFromScriptProperties } = require('../src/main/propertiesService');
+
+        const retrievedMap: Object = loadMapFromScriptProperties("BAD_MAP_KEY");
+        expect(retrievedMap).toStrictEqual({});
+    });
+
+    it("should parse and return the JSON object when the requested map key is found in the script properties", () => {
+        const groupsMapMock: GroupsMap = getRandomlyGeneratedGroupsMap();
+        const scriptPropertiesMock: Properties = new Properties();
+
+        jest.spyOn(scriptPropertiesMock, "getProperty").mockReturnValue(JSON.stringify(groupsMapMock));
+        jest.spyOn(PropertiesService, "getScriptProperties").mockReturnValue(scriptPropertiesMock);
+
+        const { loadMapFromScriptProperties } = require('../src/main/propertiesService');
+
+        const retrievedMap: Object = loadMapFromScriptProperties("MAP_KEY");
+        expect(retrievedMap).toStrictEqual(groupsMapMock);
+    });
+});

--- a/__test__/scan.test.ts
+++ b/__test__/scan.test.ts
@@ -1,0 +1,46 @@
+import { PropertiesService, SpreadsheetApp } from "gasmask";
+global.PropertiesService = PropertiesService;
+global.SpreadsheetApp = SpreadsheetApp;
+
+import Spreadsheet from "gasmask/dist/SpreadsheetApp/Spreadsheet";
+import { TabNotFoundError } from "../src/main/error/tabNotFoundError";
+import Sheet from "gasmask/dist/SpreadsheetApp/Sheet";
+import { getRandomlyGeneratedCellValues, getRandomlyGeneratedRange } from "./testUtils";
+import { Range as GasMaskRange } from "gasmask/dist/SpreadsheetApp";
+import Range from "gasmask/dist/SpreadsheetApp/Range";
+
+describe("getCellValues", () => {
+    it("should throw a TabNotFound error when the tab does not exist on the spreadsheet", () => {
+        const spreadsheetMock: Spreadsheet = new Spreadsheet("mock spreadsheet");
+        const tab1: Sheet = new Sheet("Tab1");
+        const tab2: Sheet = new Sheet("Tab2");
+        const tab3: Sheet = new Sheet("Tab3");
+
+        jest.spyOn(spreadsheetMock, "getSheets").mockReturnValue([tab1, tab2, tab3]);
+        jest.spyOn(SpreadsheetApp, "getActiveSpreadsheet").mockReturnValue(spreadsheetMock);
+
+        const { getCellValues } = require('../src/main/scan');
+
+        expect(() => getCellValues("BadTabName")).toThrow(new TabNotFoundError("No BadTabName tab found"));
+    });
+
+    it("should return the cell values for the tab when the tab exists", () => {
+        const spreadsheetMock: Spreadsheet = new Spreadsheet("mock spreadsheet");
+        const tab1: Sheet = new Sheet("Tab1");
+        const tab2: Sheet = new Sheet("TabName");
+        const tab3: Sheet = new Sheet("Tab3");
+
+        const cellValuesMock: any[][] = getRandomlyGeneratedCellValues();
+        const dataRangeMock: Range = new GasMaskRange(cellValuesMock, {}, tab2);
+
+        jest.spyOn(spreadsheetMock, "getSheets").mockReturnValue([tab1, tab2, tab3]);
+        jest.spyOn(SpreadsheetApp, "getActiveSpreadsheet").mockReturnValue(spreadsheetMock);
+        jest.spyOn(tab2, "getDataRange").mockReturnValue(dataRangeMock);
+        jest.spyOn(dataRangeMock, "getValues").mockReturnValue(cellValuesMock);
+
+        const { getCellValues } = require('../src/main/scan');
+        
+        const retrievedCellValues: Sheet = getCellValues("TabName");
+        expect(retrievedCellValues).toStrictEqual(cellValuesMock);
+    });
+});

--- a/__test__/scan.test.ts
+++ b/__test__/scan.test.ts
@@ -5,7 +5,7 @@ global.SpreadsheetApp = SpreadsheetApp;
 import Spreadsheet from "gasmask/dist/SpreadsheetApp/Spreadsheet";
 import { TabNotFoundError } from "../src/main/error/tabNotFoundError";
 import Sheet from "gasmask/dist/SpreadsheetApp/Sheet";
-import { getRandomlyGeneratedCellValues, getRandomlyGeneratedRange } from "./testUtils";
+import { getRandomlyGeneratedCellValues } from "./testUtils";
 import { Range as GasMaskRange } from "gasmask/dist/SpreadsheetApp";
 import Range from "gasmask/dist/SpreadsheetApp/Range";
 

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -274,133 +274,39 @@ export function getRandomlyGeneratedAliasTable(numCoupleAliases: number = 10): a
     return aliasTable;
 }
 
-export function getRandomlyGeneratedSheet(): Sheet {
-    return {
-        activate: jest.fn().mockReturnThis(),
-        addDeveloperMetadata: jest.fn().mockReturnThis(),
-        appendRow: jest.fn().mockReturnThis(),
-        asDataSourceSheet: jest.fn().mockReturnValue(null),
-        autoResizeColumn: jest.fn().mockReturnThis(),
-        autoResizeColumns: jest.fn().mockReturnThis(),
-        autoResizeRows: jest.fn().mockReturnThis(),
-        clear: jest.fn().mockReturnThis(),
-        clearConditionalFormatRules: jest.fn(),
-        clearContents: jest.fn().mockReturnThis(),
-        clearFormats: jest.fn().mockReturnThis(),
-        clearNotes: jest.fn().mockReturnThis(),
-        collapseAllColumnGroups: jest.fn().mockReturnThis(),
-        collapseAllRowGroups: jest.fn().mockReturnThis(),
-        copyTo: jest.fn().mockReturnThis(),
-        createDeveloperMetadataFinder: jest.fn(),
-        createTextFinder: jest.fn(),
-        deleteColumn: jest.fn().mockReturnThis(),
-        deleteColumns: jest.fn(),
-        deleteRow: jest.fn().mockReturnThis(),
-        deleteRows: jest.fn(),
-        expandAllColumnGroups: jest.fn().mockReturnThis(),
-        expandAllRowGroups: jest.fn().mockReturnThis(),
-        expandColumnGroupsUpToDepth: jest.fn().mockReturnThis(),
-        expandRowGroupsUpToDepth: jest.fn().mockReturnThis(),
-        getActiveCell: jest.fn(),
-        getActiveRange: jest.fn(),
-        getActiveRangeList: jest.fn(),
-        getBandings: jest.fn().mockReturnValue([]),
-        getCharts: jest.fn().mockReturnValue([]),
-        getColumnGroup: jest.fn(),
-        getColumnGroupControlPosition: jest.fn(),
-        getColumnGroupDepth: jest.fn().mockReturnValue(0),
-        getColumnWidth: jest.fn().mockReturnValue(0),
-        getConditionalFormatRules: jest.fn().mockReturnValue([]),
-        getCurrentCell: jest.fn(),
-        getDataRange: jest.fn(),
-        getDataSourceTables: jest.fn().mockReturnValue([]),
-        getDeveloperMetadata: jest.fn().mockReturnValue([]),
-        getDrawings: jest.fn().mockReturnValue([]),
-        getFilter: jest.fn(),
-        getFormUrl: jest.fn(),
-        getFrozenColumns: jest.fn().mockReturnValue(0),
-        getFrozenRows: jest.fn().mockReturnValue(0),
-        getImages: jest.fn().mockReturnValue([]),
-        getIndex: jest.fn().mockReturnValue(0),
-        getLastColumn: jest.fn().mockReturnValue(0),
-        getLastRow: jest.fn().mockReturnValue(0),
-        getMaxColumns: jest.fn().mockReturnValue(0),
-        getMaxRows: jest.fn().mockReturnValue(0),
-        getName: jest.fn().mockReturnValue(randomstring.generate()),
-        getNamedRanges: jest.fn().mockReturnValue([]),
-        getParent: jest.fn(),
-        getPivotTables: jest.fn().mockReturnValue([]),
-        getProtections: jest.fn().mockReturnValue([]),
-        getRange: jest.fn(),
-        getRangeList: jest.fn(),
-        getRowGroup: jest.fn(),
-        getRowGroupControlPosition: jest.fn(),
-        getRowGroupDepth: jest.fn().mockReturnValue(0),
-        getRowHeight: jest.fn().mockReturnValue(0),
-        getSelection: jest.fn(),
-        getSheetId: jest.fn().mockReturnValue(0),
-        getSheetName: jest.fn().mockReturnValue(randomstring.generate()),
-        getSheetValues: jest.fn().mockReturnValue([]),
-        getSlicers: jest.fn().mockReturnValue([]),
-        getTabColor: jest.fn(),
-        getType: jest.fn(),
-        hasHiddenGridlines: jest.fn().mockReturnValue(getRandomBoolean()),
-        hideColumn: jest.fn(),
-        hideColumns: jest.fn(),
-        hideRow: jest.fn(),
-        hideRows: jest.fn(),
-        hideSheet: jest.fn().mockReturnThis(),
-        insertChart: jest.fn(),
-        insertColumnAfter: jest.fn().mockReturnThis(),
-        insertColumnBefore: jest.fn().mockReturnThis(),
-        insertColumns: jest.fn(),
-        insertColumnsAfter: jest.fn().mockReturnThis(),
-        insertColumnsBefore: jest.fn().mockReturnThis(),
-        insertImage: jest.fn(),
-        insertRowAfter: jest.fn().mockReturnThis(),
-        insertRowBefore: jest.fn().mockReturnThis(),
-        insertRows: jest.fn(),
-        insertRowsAfter: jest.fn().mockReturnThis(),
-        insertRowsBefore: jest.fn().mockReturnThis(),
-        insertSlicer: jest.fn(),
-        isColumnHiddenByUser: jest.fn().mockReturnValue(getRandomBoolean()),
-        isRightToLeft: jest.fn().mockReturnValue(getRandomBoolean()),
-        isRowHiddenByFilter: jest.fn().mockReturnValue(getRandomBoolean()),
-        isRowHiddenByUser: jest.fn().mockReturnValue(getRandomBoolean()),
-        isSheetHidden: jest.fn().mockReturnValue(getRandomBoolean()),
-        moveColumns: jest.fn(),
-        moveRows: jest.fn(),
-        newChart: jest.fn(),
-        protect: jest.fn(),
-        removeChart: jest.fn(),
-        setActiveRange: jest.fn(),
-        setActiveRangeList: jest.fn(),
-        setActiveSelection: jest.fn(),
-        setColumnGroupControlPosition: jest.fn(),
-        setColumnWidth: jest.fn().mockReturnThis(),
-        setColumnWidths: jest.fn().mockReturnThis(),
-        setConditionalFormatRules: jest.fn(),
-        setCurrentCell: jest.fn(),
-        setFrozenColumns: jest.fn(),
-        setFrozenRows: jest.fn(),
-        setHiddenGridlines: jest.fn(),
-        setName: jest.fn(),
-        setRightToLeft: jest.fn(),
-        setRowGroupControlPosition: jest.fn(),
-        setRowHeight: jest.fn().mockReturnThis(),
-        setRowHeights: jest.fn().mockReturnThis(),
-        setRowHeightsForced: jest.fn().mockReturnThis(),
-        setTabColor: jest.fn(),
-        showColumns: jest.fn(),
-        showRows: jest.fn(),
-        showSheet: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockReturnThis(),
-        unhideColumn: jest.fn(),
-        unhideRow: jest.fn(),
-        updateChart: jest.fn(),
-        getSheetProtection: jest.fn(),
-        setSheetProtection: jest.fn(),
-    };
+export function getRandomlyGeneratedGroupsMap(numGroups: number = 10, numGroupMembers: number = 10): GroupsMap {
+    const groupsMap: GroupsMap = {};
+    for(let i = 0; i < numGroups; i++) {
+        groupsMap[randomstring.generate()] = Array.from({length: numGroupMembers}, () => randomstring.generate());
+    }
+
+    return groupsMap;
+}
+
+function getRandomlyGeneratedGroupRow(numGroupMembers: number = 3): any[] {
+    return [randomstring.generate(), randomstring.generate(), Array.from({length: numGroupMembers}, () => randomstring.generate()).join(",")];
+}
+
+export function getRandomlyGeneratedGroupsTable(numGroups: number = 10): any[][] {
+    const aliasTable: any[][] = [["Name", "Group Members"]];
+    for(let i = 0; i < numGroups; i++) {
+        aliasTable.push(getRandomlyGeneratedGroupRow());
+    }
+
+    return aliasTable;
+}
+
+function getRandomlyGeneratedSupergroupRow(numSubgroups: number = 3): any[] {
+    return [randomstring.generate(), randomstring.generate(), Array.from({length: numSubgroups}, () => randomstring.generate()).join(",")];
+}
+
+export function getRandomlyGeneratedSupergroupsTable(numGroups: number = 10): any[][] {
+    const aliasTable: any[][] = [["Name", "Subgroups"]];
+    for(let i = 0; i < numGroups; i++) {
+        aliasTable.push(getRandomlyGeneratedSupergroupRow());
+    }
+
+    return aliasTable;
 }
 
 function getRandomlyGeneratedText(): Text {

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -309,6 +309,12 @@ export function getRandomlyGeneratedSupergroupsTable(numGroups: number = 10): an
     return aliasTable;
 }
 
+export function getRandomlyGeneratedCellValues(numRows: number = 5, numColumns: number = 5): any[][] {
+    return Array.from({ length: numRows }, () =>
+        Array.from({ length: numColumns }, () => randomstring.generate())
+    );
+}
+
 function getRandomlyGeneratedText(): Text {
     return {
         value: randomstring.generate(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { onOpen } from './main/menu';
 
 export * from './main/basecamp';
+export * from './main/groups';
 export * from './main/main';
 export * from './main/members';
 export * from './main/people';

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -27,7 +27,6 @@ export function loadGroupsFromOnestopIntoScriptProperties(): void {
     const combinedGroupsMaps: GroupsMap = mergeGroupsMaps(groupsMap, supergroupsMap);
     const duplicateFreeGroupsMap: GroupsMap = removeDuplicatesFromGroupMaps(combinedGroupsMaps);
 
-    Logger.log(JSON.stringify(duplicateFreeGroupsMap));
     setScriptProperty(GROUPS_MAP_KEY, JSON.stringify(duplicateFreeGroupsMap));
 }
 
@@ -41,7 +40,17 @@ function loadGroupsFromOnestop(): GroupsMap {
         const groupName: string = rowValues[GROUP_NAME_COLUMN_INDEX];
         const groupMemberNames: string[] = getGroupMemberNames(rowValues);
 
-        groupsMap[groupName] = groupMemberNames;
+        if(groupName === "") {
+            // Skip empty entries
+            continue;
+        }
+
+        if(groupsMap.hasOwnProperty(groupName)) {
+            Logger.log(`Group ${groupName} has already been defined in the Groups table. Combining the two lists of members`);
+            groupsMap[groupName] = groupsMap[groupName].concat(groupMemberNames);
+        } else {
+            groupsMap[groupName] = groupMemberNames;
+        }
     }
 
     return groupsMap;
@@ -112,7 +121,7 @@ function constructSupergroup(rowValues: any[]): Supergroup {
 
 function getSubgroupNames(rowValues: any[]): string[] {
     const subgroupNameList: string = rowValues[SUBGROUP_COLUMN_INDEX];
-    return subgroupNameList.split(COMMA_DELIMITER).map((name) => name.trim());
+    return subgroupNameList.split(COMMA_DELIMITER).map((name) => name.trim()).filter((name) => name !== "");
 }
 
 function allSubgroupsHaveBeenLoaded(supergroup: Supergroup, loadedGroups: GroupsMap, loadedSupergroups: GroupsMap): boolean {

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -1,0 +1,195 @@
+import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
+import { getCellValues } from "./scan";
+
+const COMMA_DELIMITER: string = ",";
+const GROUPS_TAB_NAME: string = "Groups";
+const SUPERGROUPS_TAB_NAME: string = "Supergroups";
+const GROUP_NAME_COLUMN_INDEX: number = 0;
+const GROUP_MEMBER_NAMES_COLUMN_INDEX: number = 1;
+const SUPERGROUP_NAME_COLUMN_INDEX: number = 0;
+const SUBGROUP_COLUMN_INDEX: number = 1;
+const GROUPS_MAP_KEY: string = "GROUPS_MAP";
+
+// Interface declared here because this is an internal object used only during the Supergroup loading process
+declare interface Supergroup {
+    name: string,
+    subgroups: string[],
+};
+
+export const GROUPS_MAP: GroupsMap = loadMapFromScriptProperties(GROUPS_MAP_KEY) as GroupsMap;
+
+/**
+ * Loads groups and supergroups from the Onestop into script properties
+ */
+export function loadGroupsFromOnestopIntoScriptProperties(): void {
+    const groupsMap: GroupsMap = loadGroupsFromOnestop();
+    const supergroupsMap: GroupsMap = loadSupergroupsFromOnestop(groupsMap);
+    const combinedGroupsMaps: GroupsMap = mergeGroupsMaps(groupsMap, supergroupsMap);
+    const duplicateFreeGroupsMap: GroupsMap = removeDuplicatesFromGroupMaps(combinedGroupsMaps);
+
+    Logger.log(JSON.stringify(duplicateFreeGroupsMap));
+    setScriptProperty(GROUPS_MAP_KEY, JSON.stringify(duplicateFreeGroupsMap));
+}
+
+function loadGroupsFromOnestop(): GroupsMap {
+    const cellValues: any[][] = getCellValues(GROUPS_TAB_NAME);
+    const groupsMap: GroupsMap = {};
+
+    // Start at row 1 to skip the table header row
+    for(let i = 1; i < cellValues.length; i++) {
+        const rowValues: any[] = cellValues[i];
+        const groupName: string = rowValues[GROUP_NAME_COLUMN_INDEX];
+        const groupMemberNames: string[] = getGroupMemberNames(rowValues);
+
+        groupsMap[groupName] = groupMemberNames;
+    }
+
+    return groupsMap;
+}
+
+function getGroupMemberNames(rowValues: any[]): string[] {
+    const groupMemberNameList: string = rowValues[GROUP_MEMBER_NAMES_COLUMN_INDEX];
+    return groupMemberNameList.split(COMMA_DELIMITER).map((name) => name.trim()).filter((name) => name !== "");
+}
+
+function loadSupergroupsFromOnestop(loadedGroups: GroupsMap): GroupsMap {
+    const cellValues: any[][] = getCellValues(SUPERGROUPS_TAB_NAME);
+
+    const { loadedSupergroups: loadedSupergroups, missingDependentSubgroups: missingDependentSubgroups } = parseAndLoadSupergroups(cellValues, loadedGroups);
+
+    if(missingDependentSubgroups.length === cellValues.length - 1) {
+        Logger.log("Warning: None of the supergroups were loaded");
+
+        return loadedSupergroups;
+    }
+
+    const { loadedSupergroups: reprocessedSupergroups, unableToLoad: unableToLoad } = reprocessSupergroups(missingDependentSubgroups, loadedGroups, loadedSupergroups);
+
+    if(unableToLoad.length > 0) {
+        Logger.log(`Warning: Unable to load the following ${unableToLoad.length} Supergroups because all of their dependent subgroups have not been loaded ${unableToLoad.map((supergroup) => `${supergroup.name}: ${supergroup.subgroups}`)}`);
+    }
+
+    const allLoadedSupergroups: GroupsMap = mergeGroupsMaps(loadedSupergroups, reprocessedSupergroups);
+
+    return allLoadedSupergroups;
+}
+
+function parseAndLoadSupergroups(cellValues: any[][], loadedGroups: GroupsMap, ): { loadedSupergroups: GroupsMap, missingDependentSubgroups: Supergroup[] } {
+    const loadedSupergroups: GroupsMap = {};
+    const missingDependentSubgroups: Supergroup[] = [];
+
+    // Start at row 1 to skip the table header row
+    for(let i = 1; i < cellValues.length; i++) {
+        const rowValues: any[] = cellValues[i];
+        const supergroup: Supergroup = constructSupergroup(rowValues);
+
+        if(supergroup.name === "") {
+            // Skip empty entries
+            continue;
+        }
+
+        if(allSubgroupsHaveBeenLoaded(supergroup, loadedGroups, loadedSupergroups)) {
+            // Load all member names of the Supergroup
+            loadedSupergroups[supergroup.name] = loadGroupMemberNames(supergroup, loadedGroups, loadedSupergroups);
+        } else {
+            // Add to the reprocess queued to be reprocessed once its' dependencies have been loaded
+            missingDependentSubgroups.push(supergroup);
+        }
+    }
+
+    return { loadedSupergroups: loadedSupergroups, missingDependentSubgroups: missingDependentSubgroups };
+}
+
+function constructSupergroup(rowValues: any[]): Supergroup {
+    const supergroupName: string = rowValues[SUPERGROUP_NAME_COLUMN_INDEX];
+    const subgroupNames: string[] = getSubgroupNames(rowValues);
+    
+    return {
+        name: supergroupName,
+        subgroups: subgroupNames,
+    };
+}
+
+function getSubgroupNames(rowValues: any[]): string[] {
+    const subgroupNameList: string = rowValues[SUBGROUP_COLUMN_INDEX];
+    return subgroupNameList.split(COMMA_DELIMITER).map((name) => name.trim());
+}
+
+function allSubgroupsHaveBeenLoaded(supergroup: Supergroup, loadedGroups: GroupsMap, loadedSupergroups: GroupsMap): boolean {
+    const subgroupNames: string[] = supergroup.subgroups;
+    for(const subgroupName of subgroupNames) {
+        if(!loadedGroups.hasOwnProperty(subgroupName) && !loadedSupergroups.hasOwnProperty(subgroupName)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function loadGroupMemberNames(supergroup: Supergroup, loadedGroups: GroupsMap, loadedSupergroups: GroupsMap): string[] {
+    let groupMembers: string[] = [];
+    const subgroups: string[] = supergroup.subgroups;
+    for(const subgroup of subgroups) {
+        if(loadedGroups.hasOwnProperty(subgroup)) {
+            groupMembers = groupMembers.concat(loadedGroups[subgroup]);
+        } else if(loadedSupergroups.hasOwnProperty(subgroup)) {
+            groupMembers = groupMembers.concat(loadedSupergroups[subgroup]);
+        } else {
+            Logger.log(`Cannot find group members for Supergroup ${supergroup.name} and subgroup ${subgroup}`);
+        }
+    }
+
+    return groupMembers;
+}
+
+function reprocessSupergroups(missingDependentSubgroups: Supergroup[], loadedGroups: GroupsMap, loadedSupergroups: GroupsMap): { loadedSupergroups: GroupsMap, unableToLoad: Supergroup[] } {
+    let reprocessQueue: Supergroup[] = missingDependentSubgroups;
+    const reprocessedSupergroups: GroupsMap = {};
+
+    let reprocessQueueStartLength: number;
+    let allLoadedSupergroups: GroupsMap = {...loadedSupergroups};
+    do {
+        reprocessQueueStartLength = reprocessQueue.length;
+        allLoadedSupergroups = {...allLoadedSupergroups, ...reprocessedSupergroups};
+        
+        const needToBeReprocessed: Supergroup[] = [];
+        // Go through reprocess queue
+        for(let i = 0; i < reprocessQueue.length; i++) {
+            const currentSupergroup: Supergroup = reprocessQueue[i];
+            if(allSubgroupsHaveBeenLoaded(currentSupergroup, loadedGroups, allLoadedSupergroups)) {
+                reprocessedSupergroups[currentSupergroup.name] = loadGroupMemberNames(currentSupergroup, loadedGroups, allLoadedSupergroups);
+            } else {
+                needToBeReprocessed.push(currentSupergroup);
+            }
+        }
+        reprocessQueue = needToBeReprocessed;
+
+    } while(reprocessQueue.length > 0 && reprocessQueue.length < reprocessQueueStartLength);
+
+    return { loadedSupergroups: reprocessedSupergroups, unableToLoad: reprocessQueue };
+}
+
+function mergeGroupsMaps(firstGroupsMap: GroupsMap, secondGroupsMap: GroupsMap): GroupsMap {
+    const finalGroupsMap: GroupsMap = {...firstGroupsMap};
+
+    const groups: string[] = Object.keys(secondGroupsMap);
+    for(const group of groups) {
+        if(finalGroupsMap.hasOwnProperty(group)) {
+            Logger.log(`Warning: Duplicate group ${group} detected`);
+            finalGroupsMap[group] = finalGroupsMap[group].concat(secondGroupsMap[group]);
+        } else {
+            finalGroupsMap[group] = secondGroupsMap[group];
+        }
+    }
+
+    return finalGroupsMap;
+}
+
+function removeDuplicatesFromGroupMaps(groupsMap: GroupsMap): GroupsMap {
+    const processedGroupsMap: GroupsMap = {};
+    for(const [groupName, groupMembers] of Object.entries(groupsMap)) {
+        processedGroupsMap[groupName] = [...new Set(groupMembers)];
+    }
+
+    return processedGroupsMap;
+}

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -153,19 +153,17 @@ function loadGroupMemberNames(supergroup: Supergroup, loadedGroups: GroupsMap, l
 
 function reprocessSupergroups(missingDependentSubgroups: Supergroup[], loadedGroups: GroupsMap, loadedSupergroups: GroupsMap): { loadedSupergroups: GroupsMap, unableToLoad: Supergroup[] } {
     let reprocessQueue: Supergroup[] = missingDependentSubgroups;
-    let reprocessQueueStartLength: number;
+    let numProcessedLastIteration: number = Number.MAX_SAFE_INTEGER;
     let allReprocessedSupergroups: GroupsMap = {};
     let allLoadedSupergroups: GroupsMap = {...loadedSupergroups};
 
-    do {
-        reprocessQueueStartLength = reprocessQueue.length;
-
+    while(reprocessQueue.length > 0 && numProcessedLastIteration > 0) {
         const { reprocessedSupergroups: reprocessedSupergroups, needsToBeReprocessed: needToBeReprocessed } = handleReprocessQueue(reprocessQueue, allLoadedSupergroups, allReprocessedSupergroups, loadedGroups);
+        numProcessedLastIteration = Object.keys(reprocessedSupergroups).length;
         allReprocessedSupergroups = {...allReprocessedSupergroups, ...reprocessedSupergroups};
         
         reprocessQueue = needToBeReprocessed;
-
-    } while(reprocessQueue.length > 0 && reprocessQueue.length < reprocessQueueStartLength);
+    };
 
     return { loadedSupergroups: allReprocessedSupergroups, unableToLoad: reprocessQueue };
 }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -1,5 +1,5 @@
 import { TabNotFoundError } from "./error/tabNotFoundError";
-import { getScriptProperty, setScriptProperty } from "./propertiesService";
+import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
 import { getAllSpreadsheetTabs } from "./scan";
 
 const MEMBERS_TAB_NAME: string = "Members";
@@ -129,9 +129,4 @@ function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap): Alia
     }
 
     return finalAliasMap;
-}
-
-function loadMapFromScriptProperties(key: string): Object {
-    const map: string | null = getScriptProperty(key);
-    return map ? JSON.parse(map) : {};
 }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -1,5 +1,5 @@
 import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
-import { getTab } from "./scan";
+import { getCellValues } from "./scan";
 
 const MEMBERS_TAB_NAME: string = "Members";
 const COUPLES_TAB_NAME: string = "Couples";
@@ -33,9 +33,7 @@ export function loadMembersFromOnestopIntoScriptProperties(): void {
 }
 
 function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: AliasMap } {
-    const membersTab: Sheet = getTab(MEMBERS_TAB_NAME);
-    const dataRange: Range = membersTab.getDataRange();
-    const cellValues: any[][] = dataRange.getValues();
+    const cellValues: any[][] = getCellValues(MEMBERS_TAB_NAME);
 
     const memberMap: MemberMap = {};
     let alternateNamesMap: AliasMap = {};
@@ -83,10 +81,7 @@ function addAlternateNamesToMap(alternateNamesMap: AliasMap, alternateNames: str
 }
 
 function loadCouplesFromOnestop(): AliasMap {
-    const couplesTab: Sheet = getTab(COUPLES_TAB_NAME);
-    const dataRange: Range = couplesTab.getDataRange();
-    const cellValues: any[][] = dataRange.getValues();
-
+    const cellValues: any[][] = getCellValues(COUPLES_TAB_NAME);
     const aliasMap: AliasMap = {};
 
     // Start at row 1 to skip the table header row

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -1,6 +1,5 @@
-import { TabNotFoundError } from "./error/tabNotFoundError";
 import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
-import { getAllSpreadsheetTabs } from "./scan";
+import { getTab } from "./scan";
 
 const MEMBERS_TAB_NAME: string = "Members";
 const COUPLES_TAB_NAME: string = "Couples";
@@ -31,18 +30,6 @@ export function loadMembersFromOnestopIntoScriptProperties(): void {
 
     setScriptProperty(MEMBER_MAP_KEY, JSON.stringify(memberMap));
     setScriptProperty(ALIASES_MAP_KEY, JSON.stringify(combinedAliases));
-}
-
-function getTab(tabName: string): Sheet {
-    const tabs: Sheet[] = getAllSpreadsheetTabs();
-    for(const tab of tabs) {
-        const currentTabName: string = tab.getName();
-        if(currentTabName === tabName) {
-            return tab;
-        }
-    }
-
-    throw new TabNotFoundError(`No ${tabName} tab found`);
 }
 
 function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: AliasMap } {

--- a/src/main/propertiesService.ts
+++ b/src/main/propertiesService.ts
@@ -161,3 +161,15 @@ export function logDocumentProperties(): void {
       Logger.log(key + ': ' + allProperties[key]);
     }
 }
+
+/**
+ * Loads and parses a map stored in the script properties. The reutned object can be cast to its corresponding
+ * type.
+ * 
+ * @param key key that the map is stored under within the script properties
+ * @returns the map object from the script properties
+ */
+export function loadMapFromScriptProperties(key: string): Object {
+    const map: string | null = getScriptProperty(key);
+    return map ? JSON.parse(map) : {};
+}

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -1,3 +1,4 @@
+import { TabNotFoundError } from "./error/tabNotFoundError";
 import { getMetadata } from "./row";
 
 type TextStyle = GoogleAppsScript.Spreadsheet.TextStyle;
@@ -297,4 +298,22 @@ function constructDate(currentDate: Date, currentTime: Date): Date {
  */
 function getUTCHoursOffset(date: Date): number {
     return date.getTimezoneOffset() / MIN_IN_HOUR;
+}
+
+/**
+ * Retrieves a tab by name from the spreadsheet. Throws a TabNotFoundError if the tab cannot be found
+ * 
+ * @param tabName the name of tab to fetch
+ * @returns Sheet object representing the tab to retrieve
+ */
+export function getTab(tabName: string): Sheet {
+    const tabs: Sheet[] = getAllSpreadsheetTabs();
+    for(const tab of tabs) {
+        const currentTabName: string = tab.getName();
+        if(currentTabName === tabName) {
+            return tab;
+        }
+    }
+
+    throw new TabNotFoundError(`No ${tabName} tab found`);
 }

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -325,8 +325,8 @@ function getTab(tabName: string): Sheet {
  * @returns values for the cells that contain data for the given sheet
  */
 export function getCellValues(tabName: string): any[][] {
-    const groupsTab: Sheet = getTab(tabName);
-    const dataRange: Range = groupsTab.getDataRange();
+    const tab: Sheet = getTab(tabName);
+    const dataRange: Range = tab.getDataRange();
     const cellValues: any[][] = dataRange.getValues();
 
     return cellValues;

--- a/src/main/scan.ts
+++ b/src/main/scan.ts
@@ -306,7 +306,7 @@ function getUTCHoursOffset(date: Date): number {
  * @param tabName the name of tab to fetch
  * @returns Sheet object representing the tab to retrieve
  */
-export function getTab(tabName: string): Sheet {
+function getTab(tabName: string): Sheet {
     const tabs: Sheet[] = getAllSpreadsheetTabs();
     for(const tab of tabs) {
         const currentTabName: string = tab.getName();
@@ -316,4 +316,18 @@ export function getTab(tabName: string): Sheet {
     }
 
     throw new TabNotFoundError(`No ${tabName} tab found`);
+}
+
+/**
+ * Returns the cell values for a given Google Sheets tab
+ * 
+ * @param tabName the name of the tab
+ * @returns values for the cells that contain data for the given sheet
+ */
+export function getCellValues(tabName: string): any[][] {
+    const groupsTab: Sheet = getTab(tabName);
+    const dataRange: Range = groupsTab.getDataRange();
+    const cellValues: any[][] = dataRange.getValues();
+
+    return cellValues;
 }

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -112,3 +112,6 @@ type MemberMap = { [key: string]: Member };
 
 // Maps an alias to an array of member names that the alias corresponds to
 type AliasMap = { [key: string]: string[] };
+
+// Maps a group name to an array of group member names
+type GroupsMap = { [key: string]: string[] }


### PR DESCRIPTION
This PR adds group and supergroup loading from the Onestop into script properties. After the `loadGroupsFromOnestopIntoScriptProperties()` function is run, a json map is created that maps a group name to an array of all of its group members
```
{
    "IGSM": ["personName1", "personName2", ...],
    "IUSM": ["personName3", "personName4", ...],
    "IUSM": ["personName1", "personName2", "personName3", "personName4", ...], // All names from IGSM and IUSM
}
```
Onestop tables:
<img width="571" alt="Screenshot 2024-11-20 at 10 46 38 PM" src="https://github.com/user-attachments/assets/07ef391e-8f57-483e-8dba-e11f20558c3e">
<img width="499" alt="Screenshot 2024-11-20 at 10 46 45 PM" src="https://github.com/user-attachments/assets/8a5b36fa-da7d-4ab7-8278-694481ba40a5">

Logic:
Loading groups with members is pretty straightforward. Just add them to the map. Loading Supergroups (groups of groups) is more complicated. Here is the logic I implemented for loading supergroups. Definitely is not the most optimal solution such compared to building an actual dependency graph or something similar, but it works I think:
1. Go through the Supergroups table row by row
2. If all of the dependent subgroups have already been loaded, load the Supergroup
3. Otherwise if all of the dependent subgroups have not yet been loaded, add that Supergroup to a queue to be reprocessed at a later time
4. Once all rows of the Supergroup table have been processed, go through the queue of Supergroups that need to be reprocessed and do the same thing (if all of the dependent subgroups have been loaded, load the Supergroup; otherwise re-add the Supergroup to the reprocessing queue)
5. Everytime we go through the reprocessing queue, we keep track of the number of Supergroups that were loaded on that iteration. If at any point that number is 0, that means we made 0 progress on the last iteration and none of the remaining Supergroups can be loaded (likely due to a cyclical dependency)

Probably O(n^2) at the worst lol. More efficient way to do it would probably be to build an actual dependency graph and use a graph traversal algorithm that processes all of the leaves first like DFS. Would like to get your guys' thoughts about this.

This PR admittedly also has a lot of object copying in an effort to avoid using output parameters

Changes: 
* `getCellValues()` and `loadMapFromScriptProperties()` were refactored so they can be used by both member and group loading. Unit tests were added for these refactored functions
* group loading and super group loading

Unit test report:
<img width="1718" alt="Screenshot 2024-11-20 at 10 25 42 PM" src="https://github.com/user-attachments/assets/72856386-814c-495c-ac55-27733ec54364">