### PR TITLE
Added system to filter group members

### DIFF
--- a/__test__/filter.test.ts
+++ b/__test__/filter.test.ts
@@ -267,7 +267,67 @@ describe("filterMembers", () => {
 
         const expectedFilteredMembers: string[] = ["Jane Smith"];
         expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
-    })
+    });
+
+    it("should filter out moms when the Minus Moms filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Minus Moms";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["John Doe"].parent = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Jane Smith"].parent = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Alice Johnson"].parent = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["Bob Brown"].parent = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Alice Johnson", "Bob Brown"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out non-dads when the Dads filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Minus Dads";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["John Doe"].parent = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Jane Smith"].parent = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Alice Johnson"].parent = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["Bob Brown"].parent = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["Jane Smith", "Alice Johnson", "Bob Brown"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
 
     it("should apply multiple filters to the group members list when there are multiple filters in the filter list", () => {
         const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];

--- a/__test__/filter.test.ts
+++ b/__test__/filter.test.ts
@@ -1,0 +1,301 @@
+import { getRandomlyGeneratedMember } from "./testUtils";
+
+describe("filterMembers", () => {
+    it("should return an empty list when the group members list is empty", () => {
+        const groupMembersMock: string[] = [];
+        const filterListMock: string = "";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = [];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should return the same list of group members when the filter list is empty", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should remove invalid members when the group members list contains invalid members", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Charles Davis", "Alice Johnson", "Emily Clark", "Bob Brown"];
+        const filterListMock: string = "Bros";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Bob Brown"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should ignore invalid filters when there are invalid filters in the filter list", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Married, Bad Filter";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].married = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].married = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].married = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].married = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Jane Smith"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out the sisters when the Bros filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Bros";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Bob Brown"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out the brothers when the Sis filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Sis";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["Jane Smith", "Alice Johnson"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out the non-married when the Married filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Married";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].married = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].married = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].married = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].married = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Jane Smith"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out the non-parents when the Parents filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Parents";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].parent = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].parent = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].parent = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].parent = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe", "Jane Smith"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out non-dads when the Dads filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Dads";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["John Doe"].parent = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Jane Smith"].parent = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Alice Johnson"].parent = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["Bob Brown"].parent = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+
+    it("should filter out non-moms when the Moms filter is specified", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Moms";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["John Doe"].parent = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Jane Smith"].parent = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Alice Johnson"].parent = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["Bob Brown"].parent = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["Jane Smith"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    })
+
+    it("should apply multiple filters to the group members list when there are multiple filters in the filter list", () => {
+        const groupMembersMock: string[] = ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"];
+        const filterListMock: string = "Bros, Married";
+
+        const memberMapMock: MemberMap = {};
+        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
+        memberMapMock["John Doe"].gender = "Male";
+        memberMapMock["John Doe"].married = true;
+        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
+        memberMapMock["Jane Smith"].gender = "Female";
+        memberMapMock["Jane Smith"].married = true;
+        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["Alice Johnson"].gender = "Female";
+        memberMapMock["Alice Johnson"].married = false;
+        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
+        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["Bob Brown"].married = false;
+
+        jest.mock("../src/main/members", () => ({
+            MEMBER_MAP: memberMapMock,
+        }));
+
+        const { filterMembers } = require("../src/main/filter");
+
+        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+
+        const expectedFilteredMembers: string[] = ["John Doe"];
+        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { onOpen } from './main/menu';
 
 export * from './main/basecamp';
+export * from './main/filter';
 export * from './main/groups';
 export * from './main/main';
 export * from './main/members';

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -17,6 +17,8 @@ const FILTER_MAP: FilterMap = {
     Parents: parentsFilter,
     Moms: momsFilter,
     Dads: dadsFilter,
+    "Minus Moms": minusMomsFilter,
+    "Minus Dads": minusDadsFilter,
 };
 
 /**
@@ -81,4 +83,12 @@ function dadsFilter(memberName: string): boolean {
 function momsFilter(memberName: string): boolean {
     const member: Member = MEMBER_MAP[memberName];
     return member.gender === SIS_GENDER && member.parent;
+}
+
+function minusMomsFilter(memberName: string): boolean {
+    return !momsFilter(memberName);
+}
+
+function minusDadsFilter(memberName: string): boolean {
+    return !dadsFilter(memberName);
 }

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -1,0 +1,84 @@
+/**
+ * To add a new filter, create a filter function that matches the type FilterFunction and then add the mapping to the FILTER_MAP
+ */
+
+import { MEMBER_MAP } from "./members";
+
+type FilterMap = { [onestopFilterName: string]: FilterFunction };
+
+const COMMA_DELIMITER: string = ",";
+const BROS_GENDER: string = "Male";
+const SIS_GENDER: string = "Female";
+// Maps a filter's name on the Onestop to its corresponding filter function
+const FILTER_MAP: FilterMap = {
+    Bros: brosFilter, 
+    Sis: sisFilter,
+    Married: marriedFilter,
+    Parents: parentsFilter,
+    Moms: momsFilter,
+    Dads: dadsFilter,
+};
+
+/**
+ * Filters an array of group members based on the given list of filters from the Onestop
+ * 
+ * @param groupMembers array of group members to filter
+ * @param filterList comma separated list of filters from the Onestop
+ * @returns array of group members that meet all of the filters criteria
+ */
+export function filterMembers(groupMembers: string[], filterList: string): string[] {
+    return groupMembers.filter(getCombinedFilter(filterList));
+}
+
+/**
+ * Constructs a singular filtering function meant to be passed into the array filter() function that is composed of all of the filters
+ * in the given list from the Onestop. The returned filtering function should only return true if a group member meets the criteria for
+ * every filter in the list
+ * 
+ * @param filterList comma separated list of filters from the Onestop
+ * @returns singular filtering function that is composed of all of the filters from the filter list
+ */
+function getCombinedFilter(filterList: string): FilterFunction {
+    const filterNames: string[] = parseFilterNames(filterList);
+    // Gets all filter function pointers using the FILTER_MAP
+    const filterFunctions: FilterFunction[] = filterNames.map((filterName) => FILTER_MAP[filterName]).filter((filter) => filter != undefined);
+    // Adds the valid member filter to the beginning. The first filter always applied will be to check if the member is valid
+    filterFunctions.unshift(validMemberFilter);
+
+    // Returns a function which only returns true if every filter function returns true; will short circuit
+    return (memberName: string) => filterFunctions.every((filterFunction) => filterFunction(memberName));
+}
+
+function parseFilterNames(filterList: string): string[] {
+    return filterList.split(COMMA_DELIMITER).map(filterName => filterName.trim()).filter(filterName => filterName !== "");
+}
+
+function validMemberFilter(memberName: string): boolean {
+    return MEMBER_MAP.hasOwnProperty(memberName);
+}
+
+function brosFilter(memberName: string): boolean {
+    return MEMBER_MAP[memberName].gender === BROS_GENDER;
+}
+
+function sisFilter(memberName: string): boolean {
+    return MEMBER_MAP[memberName].gender === SIS_GENDER;
+}
+
+function marriedFilter(memberName: string): boolean {
+    return MEMBER_MAP[memberName].married;
+}
+
+function parentsFilter(memberName: string): boolean {
+    return MEMBER_MAP[memberName].parent;
+}
+
+function dadsFilter(memberName: string): boolean {
+    const member: Member = MEMBER_MAP[memberName];
+    return member.gender === BROS_GENDER && member.parent;
+}
+
+function momsFilter(memberName: string): boolean {
+    const member: Member = MEMBER_MAP[memberName];
+    return member.gender === SIS_GENDER && member.parent;
+}

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -115,3 +115,6 @@ type AliasMap = { [key: string]: string[] };
 
 // Maps a group name to an array of group member names
 type GroupsMap = { [key: string]: string[] }
+
+// function used to filter groups of members; meant to be used with the array filter() function
+type FilterFunction = (memberName: string) => boolean;


### PR DESCRIPTION
Added a system to be able to filter groups of members based on Andrew's comment here - https://3.basecamp.com/4474129/buckets/38736474/todos/7962234197#__recording_7963320501. Should hopefully be pretty easy to add new filters in the future if we need them. Comments on how to add new filters have been left in the code. 

At the moment, if multiple filters are applied like `Bros` and `Married`, it will combine the filters and filter out anyone that is not a Bro and is not married (the result is bros that are married). If we want to make it so that two filters like `Bros` and `Married` result in bros OR anyone that is married, it is just a 1 line change changing `every()` to `some()` on this line here - https://github.com/andrewc5716/onestop-basecamp-integration/blob/7f1ce5e9722b774c7b86b87e7c34cedc2edb6a64/src/main/filter.ts#L49