### PR TITLE
add helper cell validation

### DIFF
--- a/__test__/validation.test.ts
+++ b/__test__/validation.test.ts
@@ -1,0 +1,203 @@
+import { PropertiesService } from 'gasmask';
+global.PropertiesService = PropertiesService;
+import {isHelperCellValid} from "../src/main/validation";
+
+describe("isHelperCellValid", () => {
+    it("should allow empty", () => {
+        expect(isHelperCellValid("")).toBeTruthy();
+    });
+
+    it("should reject undefined helper", () => {
+        expect(isHelperCellValid("undefined")).toBeFalsy();
+    })
+
+    it("should allow a group name", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "GROUPS_MAP") {
+                    return {
+                        "HG2": ['Andrew Chan', 'Janice Chan']
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("HG2")).toBeTruthy();
+    });
+
+    it("should allow an alias", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "ALIASES_MAP") {
+                    return {
+                        "Andrew/Janice": ['Andrew Chan', 'Janice Chan']
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Andrew/Janice")).toBeTruthy();
+    });
+
+    it("should allow a valid member name", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"}
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Andrew Chan")).toBeTruthy();
+    });
+
+    it("should allow a valid member name with city", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"}
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Andrew Chan (Sd)")).toBeTruthy();
+    });
+
+    it("should allow for role text", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"}
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Food: Andrew Chan")).toBeTruthy();
+    });
+
+    it("should allow for filters", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "GROUPS_MAP") {
+                    return {
+                        "HG2": ['Andrew Chan', 'Janice Chan']
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("HG2 Bros")).toBeTruthy();
+    });
+
+    it("should allow for multiple lines", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"},
+                        "Janice Chan": {"gender": "Female"},
+                        "Josh Wong": {"gender": "Male"}
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Andrew Chan\nJanice Chan\nJosh Wong")).toBeTruthy();
+    });
+
+    it("should allow for comma separated list", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"},
+                        "Janice Chan": {"gender": "Female"},
+                        "Josh Wong": {"gender": "Male"}
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("Andrew Chan, Janice Chan, Josh Wong")).toBeTruthy();
+    });
+
+    it("should allow for empty entries between commas", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"},
+                        "Janice Chan": {"gender": "Female"},
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid(",,,,Andrew Chan,,,Janice Chan,,,")).toBeTruthy();
+    });
+
+    it("should allow for mixing groups, aliases, and members", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "GROUPS_MAP") {
+                    return {
+                        "SDSU": ['Josh Wong']
+                    }
+                } else if (key === "ALIASES_MAP") {
+                    return {
+                        "Jack/Angel": ['Jack Zhang', 'Angel Zhang']
+                    }
+                } else if (key === "MEMBER_MAP") {
+                    return {
+                        "Andrew Chan": {"gender": "Male"},
+                        "Janice Chan": {"gender": "Female"},
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("SDSU, Jack/Angel\nFood: Andrew Chan\nJanice Chan")).toBeTruthy();
+    });
+
+    it("should allow the word staff", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "GROUPS_MAP") {
+                    return {
+                        "SDSU": ['Josh Wong']
+                    }
+                }
+                return {};
+            }),
+        }));
+        const { isHelperCellValid } = require("../src/main/validation");
+
+        expect(isHelperCellValid("SDSU staff")).toBeTruthy();
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './main/row';
 export * from './main/scan';
 export * from './main/todos';
 export * from './main/schedule';
+export * from './main/validation';
 
 // Re-export all the exports from `menu` module into Webpack `globalThis` scope, so they are available at runtime
 // for the Google Apps Script to call.

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -9,7 +9,7 @@ type FilterMap = { [onestopFilterName: string]: FilterFunction };
 const BROS_GENDER: string = "Male";
 const SIS_GENDER: string = "Female";
 // Maps a filter's name on the Onestop to its corresponding filter function
-export const FILTER_MAP: FilterMap = {
+const FILTER_MAP: FilterMap = {
     Bros: brosFilter, 
     Sis: sisFilter,
     Married: marriedFilter,

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -9,7 +9,7 @@ type FilterMap = { [onestopFilterName: string]: FilterFunction };
 const BROS_GENDER: string = "Male";
 const SIS_GENDER: string = "Female";
 // Maps a filter's name on the Onestop to its corresponding filter function
-const FILTER_MAP: FilterMap = {
+export const FILTER_MAP: FilterMap = {
     Bros: brosFilter, 
     Sis: sisFilter,
     Married: marriedFilter,

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -95,7 +95,7 @@ function getPersonIdFromCache(personName: string): string | undefined {
  * @param rawPersonName person name that may include city in parenthesis or middle names, e.g. Andrew Chan (Sd)
  * @returns the person's first and last name only, e.g. Andrew Chan
  */
-function normalizePersonName(rawPersonName: string): string {
+export function normalizePersonName(rawPersonName: string): string {
     const parenthesisIndex = rawPersonName.indexOf('(');
     const nameWithoutParenthesis = parenthesisIndex === -1 ? rawPersonName : rawPersonName.slice(0, parenthesisIndex);
     const fullName = nameWithoutParenthesis.trim().split(' ');

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -1,0 +1,50 @@
+import { GROUPS_MAP } from "./groups";
+import { ALIASES_MAP, MEMBER_MAP } from "./members";
+import { removeFilters } from "./filter";
+import { normalizePersonName } from "./people";
+
+const NEW_LINE_DELIM: string = "\n";
+const COLON_DELIM: string = ":";
+const COMMA_DELIMITER: string = ",";
+const STAFF_REGEX: RegExp = /\bstaff\b/gi;
+
+export function isHelperCellValid(helperCellText: string): boolean {
+    const helperLines: string[] = helperCellText.split(NEW_LINE_DELIM);
+    return helperLines.every(isHelperLineValid);
+}
+
+function isHelperLineValid(helperLine: string): boolean {
+    const helperList: string = removeRoleTextFromHelperLine(helperLine);
+    const helpers: string[] = helperList.split(COMMA_DELIMITER);
+    return helpers.every(isHelperTokenValid);
+}
+
+function removeRoleTextFromHelperLine(helperLine: string): string {
+    const colonIndex = helperLine.indexOf(COLON_DELIM);
+    if(colonIndex !== -1) {
+        return helperLine.substring(colonIndex + 1).trim();
+    }
+    return helperLine;
+}
+
+function isHelperTokenValid(helperTokenWithFilters: string): boolean {
+    if(helperTokenWithFilters === "") {
+        return true;
+    }
+    const { stringWithoutFilters: helperWithoutFilters } = removeFilters(helperTokenWithFilters);
+    const normalizedHelper: string = normalizeHelper(helperWithoutFilters)
+
+    if(GROUPS_MAP.hasOwnProperty(normalizedHelper)) {
+        return true;
+    } else if(ALIASES_MAP.hasOwnProperty(normalizedHelper)) {
+        return true;
+    } else if(MEMBER_MAP.hasOwnProperty(normalizePersonName(normalizedHelper))) {
+        return true;
+    }
+    return false;
+}
+
+function normalizeHelper(helper: string): string {
+    // todo: make the whole helper input lowercase; but need to make all the maps lowercase too then to make it work
+    return helper.replace(STAFF_REGEX, '').trim();
+}


### PR DESCRIPTION
create a function for validating a helper cell. unfortunately this function can't be used from data > data validation > custom formula. it has to be indirectly used, so in a hidden column, e.g. H, run `isHelperCellValid(A1)`, then in data validation, do `H1=TRUE`.
currently it's named to be used for the helper cell, but honestly this can just be used for the lead cell too. technically a group can't be put in there, but the code is almost identical so i'm ok with shortcutting this for now?