### PR TITLE
Group aliasing

### DIFF
--- a/__test__/aliases.test.ts
+++ b/__test__/aliases.test.ts
@@ -1,0 +1,73 @@
+import { Logger, PropertiesService } from 'gasmask';
+global.Logger = Logger;
+global.PropertiesService = PropertiesService;
+
+import { mergeAliasMaps } from "../src/main/aliases";
+import { getRandomlyGeneratedAliasMap, Mock } from "./testUtils";
+import randomstring from "randomstring";
+
+describe("ALIASES_MAP", () => {
+    it("should return the aliases map from the script properties when it is present", () => {
+        const aliasesMapMock: AliasMap = getRandomlyGeneratedAliasMap();
+
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => aliasesMapMock),
+        }));
+        
+        const { ALIASES_MAP } = require('../src/main/aliases');
+
+        expect(ALIASES_MAP).toEqual(aliasesMapMock);
+    });
+
+    it("should return an empty map when there is no aliases map present in the script properties", () => {
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+        }));
+
+        const { ALIASES_MAP } = require('../src/main/aliases');
+
+        expect(ALIASES_MAP).toStrictEqual({});
+    });
+});
+
+describe("saveAliasMap", () => {
+    it("should save the given alias map to the script properties when the function is called", () => {
+        const aliasMapMock: AliasMap = getRandomlyGeneratedAliasMap();
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { saveAliasMap } = require('../src/main/aliases');
+        saveAliasMap(aliasMapMock);
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("ALIASES_MAP", JSON.stringify(aliasMapMock));
+    });
+});
+
+describe("mergeAliasMaps", () => {
+    it("should merge the two alias maps when there are no overlaps", () => {
+        const firstAliasMap: AliasMap = { "John D": [randomstring.generate()] };
+        const secondAliasMap: AliasMap = { "Mary B": [randomstring.generate()] };
+        const expectedMergedAliasMap: AliasMap = {
+            "John D": firstAliasMap["John D"],
+            "Mary B": secondAliasMap["Mary B"],
+        };
+
+        const mergedAliasMap: AliasMap = mergeAliasMaps(firstAliasMap, secondAliasMap);
+        expect(mergedAliasMap).toStrictEqual(expectedMergedAliasMap);
+    });
+
+    it("should add duplicate aliases to the member list when there are duplicate aliases", () => {
+        const firstAliasMap: AliasMap = { "John": [randomstring.generate()] };
+        const secondAliasMap: AliasMap = { "John": [randomstring.generate()] };
+        const expectedMergedAliasMap: AliasMap = {
+            "John": [firstAliasMap["John"][0], secondAliasMap["John"][0]],
+        };
+
+        const mergedAliasMap: AliasMap = mergeAliasMaps(firstAliasMap, secondAliasMap);
+        expect(mergedAliasMap).toStrictEqual(expectedMergedAliasMap);
+    });
+});

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -458,9 +458,3 @@ describe("importOnestopToBasecamp", () => {
         expect(deleteScheduleEntryMock).toHaveBeenCalledTimes(0);
     });
 });
-
-describe("loadDataFromOnestopIntoScriptProperties", () => {
-    it("should when", () => {
-
-    });
-});

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -458,3 +458,9 @@ describe("importOnestopToBasecamp", () => {
         expect(deleteScheduleEntryMock).toHaveBeenCalledTimes(0);
     });
 });
+
+describe("loadDataFromOnestopIntoScriptProperties", () => {
+    it("should when", () => {
+
+    });
+});

--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -569,6 +569,9 @@ describe("getHelperGroups", () => {
 
         jest.mock("../src/main/members", () => ({
             MEMBER_MAP: memberMapMock,
+        }));
+
+        jest.mock("../src/main/aliases", () => ({
             ALIASES_MAP: { "John/Jane": ["John Doe", "Jane Smith"] },
         }));
 

--- a/__test__/utils.test.ts
+++ b/__test__/utils.test.ts
@@ -64,7 +64,7 @@ describe("deleteAllRowMetadataAndDocumentProperties", () => {
     });
 });
 
-describe("loadDataFromOnestopIntoScriptProperties", () => {
+describe("loadMembersAndGroupsFromOnestopIntoScriptProperties", () => {
     it("should when", () => {
 
     });

--- a/__test__/utils.test.ts
+++ b/__test__/utils.test.ts
@@ -19,6 +19,7 @@ describe("deleteAllRowMetadata", () => {
 
         jest.mock("../src/main/propertiesService", () => ({
             deleteAllDocumentProperties: jest.fn(),
+            loadMapFromScriptProperties: jest.fn(() => ({})),
         }));
 
         const { deleteAllRowMetadata } = require("../src/main/utils");
@@ -50,6 +51,7 @@ describe("deleteAllRowMetadataAndDocumentProperties", () => {
         const deleteAllDocumentPropertiesMock: Mock = jest.fn();
         jest.mock("../src/main/propertiesService", () => ({
             deleteAllDocumentProperties: deleteAllDocumentPropertiesMock,
+            loadMapFromScriptProperties: jest.fn(() => ({})),
         }));
 
         const { deleteAllRowMetadataAndDocumentProperties } = require("../src/main/utils");
@@ -59,5 +61,11 @@ describe("deleteAllRowMetadataAndDocumentProperties", () => {
         expect(metadataRemoveMock1).toHaveBeenCalledTimes(1);
         expect(metadataRemoveMock2).toHaveBeenCalledTimes(1);
         expect(deleteAllDocumentPropertiesMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("loadDataFromOnestopIntoScriptProperties", () => {
+    it("should when", () => {
+
     });
 });

--- a/__test__/utils.test.ts
+++ b/__test__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getRandomlyGeneratedRow, Mock } from "./testUtils";
+import { getRandomlyGeneratedAliasMap, getRandomlyGeneratedRow, Mock } from "./testUtils";
 
 describe("deleteAllRowMetadata", () => {
     it("should delete all row metadata when called", () => {
@@ -65,7 +65,34 @@ describe("deleteAllRowMetadataAndDocumentProperties", () => {
 });
 
 describe("loadMembersAndGroupsFromOnestopIntoScriptProperties", () => {
-    it("should when", () => {
+    it("should load members and groups and aliases into script properties when called", () => {
+        const membersAliasMapMock: AliasMap = getRandomlyGeneratedAliasMap();
+        const groupAliasMapMock: AliasMap = getRandomlyGeneratedAliasMap();
+        const combinedAliasMapsMock: AliasMap = {...membersAliasMapMock, ...groupAliasMapMock};
 
+        jest.mock("../src/main/members", () => ({
+            loadMembersFromOnestopIntoScriptProperties: jest.fn(() => membersAliasMapMock),
+        }));
+
+        jest.mock("../src/main/groups", () => ({
+            loadGroupsFromOnestopIntoScriptProperties: jest.fn(() => groupAliasMapMock),
+        }));
+
+        const mergeAliasMapsMock: Mock = jest.fn(() => combinedAliasMapsMock);
+        const saveAliasMapMock: Mock = jest.fn();
+        jest.mock("../src/main/aliases", () => ({
+            mergeAliasMaps: mergeAliasMapsMock,
+            saveAliasMap: saveAliasMapMock,
+        }));
+
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+        }));
+
+        const { loadMembersAndGroupsFromOnestopIntoScriptProperties } = require("../src/main/utils");
+        loadMembersAndGroupsFromOnestopIntoScriptProperties();
+
+        expect(mergeAliasMapsMock).toHaveBeenCalledWith(membersAliasMapMock, groupAliasMapMock);
+        expect(saveAliasMapMock).toHaveBeenCalledWith(combinedAliasMapsMock);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { onOpen } from './main/menu';
 
+export * from './main/aliases';
 export * from './main/basecamp';
 export * from './main/filter';
 export * from './main/groups';

--- a/src/main/aliases.ts
+++ b/src/main/aliases.ts
@@ -1,0 +1,25 @@
+import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
+
+const ALIASES_MAP_KEY: string = "ALIASES_MAP";
+
+export const ALIASES_MAP: AliasMap = loadMapFromScriptProperties(ALIASES_MAP_KEY) as AliasMap;
+
+export function saveAliasMap(aliasMap: AliasMap): void {
+    setScriptProperty(ALIASES_MAP_KEY, JSON.stringify(aliasMap));
+}
+
+export function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap): AliasMap {
+    const finalAliasMap: AliasMap = { ...firstAliasMap};
+
+    const aliases: string[] = Object.keys(secondAliasMap);
+    for(const alias of aliases) {
+        if(finalAliasMap.hasOwnProperty(alias)) {
+            Logger.log(`Warning: Duplicate alias ${alias} detected`);
+            finalAliasMap[alias] = finalAliasMap[alias].concat(secondAliasMap[alias]);
+        } else {
+            finalAliasMap[alias] = secondAliasMap[alias];
+        }
+    }
+
+    return finalAliasMap;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,6 @@
+import { mergeAliasMaps, saveAliasMap } from "./aliases";
+import { loadGroupsFromOnestopIntoScriptProperties } from "./groups";
+import { loadMembersFromOnestopIntoScriptProperties } from "./members";
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
 import { getRoleTodoIdMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow } from "./row";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
@@ -124,4 +127,11 @@ function deleteOldRows(processedRowIds: string[]): void {
 
 function isInFuture(date: Date): boolean {
     return date.getTime() > Date.now();
+}
+
+export function loadDataFromOnestopIntoScriptProperties(): void {
+    const membersAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
+    const groupAliasMap: AliasMap = loadGroupsFromOnestopIntoScriptProperties();
+    const combinedAliasMaps: AliasMap = mergeAliasMaps(membersAliasMap, groupAliasMap);
+    saveAliasMap(combinedAliasMaps);
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,3 @@
-import { mergeAliasMaps, saveAliasMap } from "./aliases";
-import { loadGroupsFromOnestopIntoScriptProperties } from "./groups";
-import { loadMembersFromOnestopIntoScriptProperties } from "./members";
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
 import { getRoleTodoIdMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow } from "./row";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
@@ -127,11 +124,4 @@ function deleteOldRows(processedRowIds: string[]): void {
 
 function isInFuture(date: Date): boolean {
     return date.getTime() > Date.now();
-}
-
-export function loadDataFromOnestopIntoScriptProperties(): void {
-    const membersAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
-    const groupAliasMap: AliasMap = loadGroupsFromOnestopIntoScriptProperties();
-    const combinedAliasMaps: AliasMap = mergeAliasMaps(membersAliasMap, groupAliasMap);
-    saveAliasMap(combinedAliasMaps);
 }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -1,3 +1,4 @@
+import { mergeAliasMaps } from "./aliases";
 import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
 import { getCellValues } from "./scan";
 
@@ -14,22 +15,20 @@ const WIFE_COLUMN_INDEX: number = 1;
 const COUPLES_ALIASES_COLUMN_INDEX: number = 2;
 const COMMA_DELIMITER: string = ",";
 const MEMBER_MAP_KEY: string = "MEMBER_MAP";
-const ALIASES_MAP_KEY: string = "ALIASES_MAP";
-
 
 export const MEMBER_MAP: MemberMap = loadMapFromScriptProperties(MEMBER_MAP_KEY) as MemberMap;
-export const ALIASES_MAP: AliasMap = loadMapFromScriptProperties(ALIASES_MAP_KEY) as AliasMap;
 
 /**
  * Loads data from the Members and Couples tables on the Onestop into the script properties
  */
-export function loadMembersFromOnestopIntoScriptProperties(): void {
+export function loadMembersFromOnestopIntoScriptProperties(): AliasMap {
     const { memberMap: memberMap, alternateNamesMap: alternateNamesMap } = loadMembersFromOnestop();
     const coupleAliases: AliasMap = loadCouplesFromOnestop();
     const combinedAliases: AliasMap = mergeAliasMaps(alternateNamesMap, coupleAliases);
 
     setScriptProperty(MEMBER_MAP_KEY, JSON.stringify(memberMap));
-    setScriptProperty(ALIASES_MAP_KEY, JSON.stringify(combinedAliases));
+
+    return combinedAliases;
 }
 
 function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: AliasMap } {
@@ -95,20 +94,4 @@ function loadCouplesFromOnestop(): AliasMap {
     }
 
     return aliasMap;
-}
-
-function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap): AliasMap {
-    const finalAliasMap: AliasMap = firstAliasMap;
-
-    const aliases: string[] = Object.keys(secondAliasMap);
-    for(const alias of aliases) {
-        if(finalAliasMap.hasOwnProperty(alias)) {
-            Logger.log(`Warning: ${alias} is being used as both an alternate name and a couples' alias`);
-            finalAliasMap[alias] = finalAliasMap[alias].concat(secondAliasMap[alias]);
-        } else {
-            finalAliasMap[alias] = secondAliasMap[alias];
-        }
-    }
-
-    return finalAliasMap;
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -1,10 +1,10 @@
+import { ALIASES_MAP } from "./aliases";
 import { InvalidHashError } from "./error/invalidHashError";
 import { RowBasecampMappingMissingError } from "./error/rowBasecampMappingMissingError";
 import { RowMissingIdError } from "./error/rowMissingIdError";
 import { RowNotSavedError } from "./error/rowNotSavedError";
 import { containsFilter, filterMembers, isFilter, removeFilters } from "./filter";
 import { GROUPS_MAP, getMembersFromGroups, GROUP_NAMES } from "./groups";
-import { ALIASES_MAP } from "./members";
 import { getPersonId } from "./people";
 import { getDocumentProperty, setDocumentProperty } from "./propertiesService";
 import { getBasecampScheduleEntryRequest } from "./schedule";

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -144,8 +144,14 @@ type MemberMap = { [key: string]: Member };
 // Maps an alias to an array of member names that the alias corresponds to
 type AliasMap = { [key: string]: string[] };
 
+declare interface Group {
+  name: string,
+  members: string[],
+  aliases: string[],
+}
+
 // Maps a group name to an array of group member names
-type GroupsMap = { [key: string]: string[] }
+type GroupsMap = { [key: string]: string[] };
 
 // function used to filter groups of members; meant to be used with the array filter() function
 type FilterFunction = (memberName: string) => boolean;

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -18,7 +18,7 @@ export function deleteAllRowMetadataAndDocumentProperties(): void {
     deleteAllDocumentProperties();
 }
 
-export function loadDataFromOnestopIntoScriptProperties(): void {
+export function loadMembersAndGroupsFromOnestopIntoScriptProperties(): void {
     const membersAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
     const groupAliasMap: AliasMap = loadGroupsFromOnestopIntoScriptProperties();
     const combinedAliasMaps: AliasMap = mergeAliasMaps(membersAliasMap, groupAliasMap);

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,5 +1,8 @@
 // Utilities module that provides some helpful functions for developing/debugging Google Apps Script
 
+import { mergeAliasMaps, saveAliasMap } from "./aliases";
+import { loadGroupsFromOnestopIntoScriptProperties } from "./groups";
+import { loadMembersFromOnestopIntoScriptProperties } from "./members";
 import { deleteAllDocumentProperties } from "./propertiesService";
 import { getEventRowsFromSpreadsheet } from "./scan";
 
@@ -13,4 +16,11 @@ export function deleteAllRowMetadata(): void {
 export function deleteAllRowMetadataAndDocumentProperties(): void {
     deleteAllRowMetadata();
     deleteAllDocumentProperties();
+}
+
+export function loadDataFromOnestopIntoScriptProperties(): void {
+    const membersAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
+    const groupAliasMap: AliasMap = loadGroupsFromOnestopIntoScriptProperties();
+    const combinedAliasMaps: AliasMap = mergeAliasMaps(membersAliasMap, groupAliasMap);
+    saveAliasMap(combinedAliasMaps);
 }

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -1,7 +1,8 @@
 import { GROUPS_MAP } from "./groups";
-import { ALIASES_MAP, MEMBER_MAP } from "./members";
+import { MEMBER_MAP } from "./members";
 import { removeFilters } from "./filter";
 import { normalizePersonName } from "./people";
+import { ALIASES_MAP } from "./aliases";
 
 const NEW_LINE_DELIM: string = "\n";
 const COLON_DELIM: string = ":";


### PR DESCRIPTION
Adds group aliasing and refactors the way aliases are loaded since they are now shared by both members and groups. To perform all loading, we now just need to trigger `loadMembersAndGroupsFromOnestopIntoScriptProperties()`. Calling the individual member or group loading functions will leave out any aliases

Not all unit tests are done for this too, but was tested manually. Opening due to tight timeline

New format of tables with added alias column
![Screenshot 2025-01-25 at 6 37 08 PM](https://github.com/user-attachments/assets/fe9df1bf-d5a5-49be-afbd-eaec5efbd637)
![Screenshot 2025-01-25 at 6 37 20 PM](https://github.com/user-attachments/assets/6ffa2f0b-af03-4b36-bcb7-7b356082c395)
