### PR TITLE
Add support additional members in supergroups

### DIFF
--- a/__test__/groups.test.ts
+++ b/__test__/groups.test.ts
@@ -7,6 +7,7 @@ const GROUP_NAME_COLUMN_INDEX: number = 0;
 const GROUP_MEMBERS_COLUMN_INDEX: number = 1;
 const SUPERGROUP_NAME_COLUMN_INDEX: number = 0;
 const SUPERGROUP_SUBGROUP_COLUMN_INDEX: number = 1;
+const SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX: number = 3;
 
 describe("GROUPS_MAP", () => {
     it("should return the groups map from the script properties when it is present", () => {
@@ -170,10 +171,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -214,11 +218,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Everyone";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, Community, International";
-        
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -261,10 +267,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -307,10 +316,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -355,10 +367,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "A2K";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "SDSU";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -402,10 +417,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -450,10 +468,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
         supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
         supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "Everyone";
         supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, International";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
         supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "International";
         supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "IUSM, IGSM";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -478,6 +499,108 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
             International: ["Charlie Davis", "Emily Clark", "Frank Miller", "Grace Wilson"],
             UCSD: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown"],
             Everyone: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown", "Emily Clark", "Frank Miller", "Grace Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should load additional supergroup members when a supergroup has additional members", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "Robert Brown";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "William Johnson, Olivia Wilson";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "Sophia Martinez, Emma Anderson, Casey Morgan";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            Community: ["Frank Miller", "Grace Wilson", "Sophia Martinez", "Emma Anderson", "Casey Morgan"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown"],
+            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown", "Charlie Davis", "Emily Clark", "William Johnson", "Olivia Wilson"],
+        };
+
+        expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
+    });
+
+    it("should remove duplicate members when members are part of the additional members for a supergroup and one of its subgroups", () => {
+        const groupsDataValuesMock: any[][] = getRandomlyGeneratedGroupsTable(4);
+        const supergroupsDataValuesMock: any[][] = getRandomlyGeneratedSupergroupsTable(3);
+
+        groupsDataValuesMock[1][GROUP_NAME_COLUMN_INDEX] = "HG1";
+        groupsDataValuesMock[1][GROUP_MEMBERS_COLUMN_INDEX] = "John Doe, Jane Smith";
+        groupsDataValuesMock[2][GROUP_NAME_COLUMN_INDEX] = "HG2";
+        groupsDataValuesMock[2][GROUP_MEMBERS_COLUMN_INDEX] = "Alice Johnson, Bob Brown";
+        groupsDataValuesMock[3][GROUP_NAME_COLUMN_INDEX] = "SDSU";
+        groupsDataValuesMock[3][GROUP_MEMBERS_COLUMN_INDEX] = "Charlie Davis, Emily Clark";
+        groupsDataValuesMock[4][GROUP_NAME_COLUMN_INDEX] = "A2K";
+        groupsDataValuesMock[4][GROUP_MEMBERS_COLUMN_INDEX] = "Frank Miller, Grace Wilson";
+
+        supergroupsDataValuesMock[1][SUPERGROUP_NAME_COLUMN_INDEX] = "UCSD";
+        supergroupsDataValuesMock[1][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "HG1, HG2";
+        supergroupsDataValuesMock[1][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "Robert Brown";
+        supergroupsDataValuesMock[2][SUPERGROUP_NAME_COLUMN_INDEX] = "College";
+        supergroupsDataValuesMock[2][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "UCSD, SDSU";
+        supergroupsDataValuesMock[2][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "Robert Brown";
+        supergroupsDataValuesMock[3][SUPERGROUP_NAME_COLUMN_INDEX] = "Community";
+        supergroupsDataValuesMock[3][SUPERGROUP_SUBGROUP_COLUMN_INDEX] = "A2K";
+        supergroupsDataValuesMock[3][SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX] = "";
+
+        jest.mock("../src/main/scan", () => ({
+            getCellValues: jest.fn()
+            .mockReturnValueOnce(groupsDataValuesMock)
+            .mockReturnValueOnce(supergroupsDataValuesMock),
+        }));
+
+        const setScriptPropertyMock: Mock = jest.fn();
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+            setScriptProperty: setScriptPropertyMock,
+        }));
+
+        const { loadGroupsFromOnestopIntoScriptProperties } = require('../src/main/groups');
+        loadGroupsFromOnestopIntoScriptProperties();
+
+        const expectedMap: GroupsMap = {
+            HG1: ["John Doe", "Jane Smith"],
+            HG2: ["Alice Johnson", "Bob Brown"],
+            SDSU: ["Charlie Davis", "Emily Clark"],
+            A2K: ["Frank Miller", "Grace Wilson"],
+            Community: ["Frank Miller", "Grace Wilson"],
+            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown"],
+            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown", "Charlie Davis", "Emily Clark"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -289,25 +289,25 @@ function getRandomlyGeneratedGroupRow(numGroupMembers: number = 3): any[] {
 }
 
 export function getRandomlyGeneratedGroupsTable(numGroups: number = 10): any[][] {
-    const aliasTable: any[][] = [["Name", "Group Members"]];
+    const groupsTable: any[][] = [["Name", "Group Members", "Alternate Names"]];
     for(let i = 0; i < numGroups; i++) {
-        aliasTable.push(getRandomlyGeneratedGroupRow());
+        groupsTable.push(getRandomlyGeneratedGroupRow());
     }
 
-    return aliasTable;
+    return groupsTable;
 }
 
-function getRandomlyGeneratedSupergroupRow(numSubgroups: number = 3): any[] {
-    return [randomstring.generate(), randomstring.generate(), Array.from({length: numSubgroups}, () => randomstring.generate()).join(",")];
+function getRandomlyGeneratedSupergroupRow(numSubgroups: number = 3, numAdditionalMembers: number = 2): any[] {
+    return [randomstring.generate(), Array.from({length: numSubgroups}, () => randomstring.generate()).join(","), randomstring.generate(), Array.from({length: numAdditionalMembers}, () => randomstring.generate()).join(",")];
 }
 
 export function getRandomlyGeneratedSupergroupsTable(numGroups: number = 10): any[][] {
-    const aliasTable: any[][] = [["Name", "Subgroups"]];
+    const supergroupsTable: any[][] = [["Name", "Subgroups", "Alternate Names", "Additional Members"]];
     for(let i = 0; i < numGroups; i++) {
-        aliasTable.push(getRandomlyGeneratedSupergroupRow());
+        supergroupsTable.push(getRandomlyGeneratedSupergroupRow());
     }
 
-    return aliasTable;
+    return supergroupsTable;
 }
 
 export function getRandomlyGeneratedCellValues(numRows: number = 5, numColumns: number = 5): any[][] {


### PR DESCRIPTION
Quick PR to add an Additional Members column to Supergroups
![Screenshot 2025-01-27 at 10 22 13 AM](https://github.com/user-attachments/assets/401508c9-d680-4337-a2e0-d3b75ac41b47)
See https://3.basecamp.com/4474129/buckets/38736474/todos/8178698599 for the motivation/reasoning