### PR TITLE
Normalize all inputs

### DIFF
--- a/__test__/filter.test.ts
+++ b/__test__/filter.test.ts
@@ -6,27 +6,27 @@ import { getRandomlyGeneratedMember } from "./testUtils";
 
 describe("removeFilters", () => {
     it("should return the original string and an empty array when the input string does not contain any filters", () => {
-        const inputString: string = "IGSM";
+        const inputString: string = "igsm";
         const expectedOutput: { stringWithoutFilters: string, removedFilters: string[] } = { stringWithoutFilters: inputString, removedFilters: [] };
         expect(removeFilters(inputString)).toStrictEqual(expectedOutput);
     });
 
     it("should remove a filter from the input string when the input string contains a filter", () => {
-        const inputString: string = "IGSM Bros";
-        const expectedOutput: { stringWithoutFilters: string, removedFilters: string[] } = { stringWithoutFilters: "IGSM", removedFilters: ["Bros"] };
+        const inputString: string = "igsm Bros";
+        const expectedOutput: { stringWithoutFilters: string, removedFilters: string[] } = { stringWithoutFilters: "igsm", removedFilters: ["bros"] };
         expect(removeFilters(inputString)).toStrictEqual(expectedOutput);
     });
 
     it("should remove multiple filters from the input string when the input string contains multiple filters", () => {
-        const inputString: string = "IGSM Married Bros";
-        const expectedOutput: { stringWithoutFilters: string, removedFilters: string[] } = { stringWithoutFilters: "IGSM", removedFilters: ["Bros", "Married"] };
+        const inputString: string = "igsm Married Bros";
+        const expectedOutput: { stringWithoutFilters: string, removedFilters: string[] } = { stringWithoutFilters: "igsm", removedFilters: ["bros", "married"] };
         expect(removeFilters(inputString)).toStrictEqual(expectedOutput);
     });
 });
 
 describe("containsFilter", () => {
     it("should return true when the input string contains a filter", () => {
-        const inputString: string = "IGSM Bros";
+        const inputString: string = "igsm Bros";
         expect(containsFilter(inputString)).toBeTruthy();
     });
 
@@ -119,10 +119,10 @@ describe("filterMembers", () => {
 
         const { filterMembers } = require("../src/main/filter");
 
-        const filtertedMembers: string[] = filterMembers(groupMembersMock, filterListMock);
+        const filteredMembers: string[] = filterMembers(groupMembersMock, filterListMock);
 
         const expectedFilteredMembers: string[] = ["John Doe", "Bob Brown"];
-        expect(filtertedMembers).toStrictEqual(expectedFilteredMembers);
+        expect(filteredMembers).toStrictEqual(expectedFilteredMembers);
     });
 
     it("should ignore invalid filters when there are invalid filters in the filter list", () => {

--- a/__test__/groups.test.ts
+++ b/__test__/groups.test.ts
@@ -62,9 +62,9 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            IGSM: ["John Doe", "Jane Smith"],
-            A2K: ["Alice Johnson", "Bob Brown"],
-            IUSM: ["Charlie Davis", "Emily Clark"],
+            igsm: ["john doe", "jane smith"],
+            a2k: ["alice johnson", "bob brown"],
+            iusm: ["charlie davis", "emily clark"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -115,7 +115,7 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            IGSM: []
+            igsm: []
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -148,8 +148,8 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            IGSM: ["John Doe", "Jane Smith", "Charlie Davis", "Emily Clark"],
-            A2K: ["Alice Johnson", "Bob Brown"],
+            igsm: ["john doe", "jane smith", "charlie davis", "emily clark"],
+            a2k: ["alice johnson", "bob brown"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -191,13 +191,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
-            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown"],
+            college: ["john doe", "jane smith", "alice johnson", "bob brown", "charlie davis", "emily clark"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -236,11 +236,11 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith"],
-            Everyone: ["John Doe", "Jane Smith", "Frank Miller", "Grace Wilson"],
+            hg1: ["john doe", "jane smith"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith"],
+            everyone: ["john doe", "jane smith", "frank miller", "grace wilson"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -282,11 +282,11 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -328,13 +328,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
-            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
-            Community: ["Frank Miller", "Grace Wilson"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown"],
+            college: ["john doe", "jane smith", "alice johnson", "bob brown", "charlie davis", "emily clark"],
+            community: ["frank miller", "grace wilson"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -376,12 +376,12 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson", "Charlie Davis", "Emily Clark"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
-            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Charlie Davis", "Emily Clark"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson", "charlie davis", "emily clark"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown"],
+            college: ["john doe", "jane smith", "alice johnson", "bob brown", "charlie davis", "emily clark"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -423,13 +423,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson"],
-            College: [],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson"],
+            college: [],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -471,13 +471,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith", "Charlie Davis"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            IUSM: ["Charlie Davis", "Emily Clark"],
-            IGSM: ["Frank Miller", "Grace Wilson"],
-            International: ["Charlie Davis", "Emily Clark", "Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown"],
-            Everyone: ["John Doe", "Jane Smith", "Charlie Davis", "Alice Johnson", "Bob Brown", "Emily Clark", "Frank Miller", "Grace Wilson"],
+            hg1: ["john doe", "jane smith", "charlie davis"],
+            hg2: ["alice johnson", "bob brown"],
+            iusm: ["charlie davis", "emily clark"],
+            igsm: ["frank miller", "grace wilson"],
+            international: ["charlie davis", "emily clark", "frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith", "charlie davis", "alice johnson", "bob brown"],
+            everyone: ["john doe", "jane smith", "charlie davis", "alice johnson", "bob brown", "emily clark", "frank miller", "grace wilson"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -486,15 +486,15 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
 
 // Mocked GROUPS_MAP
 const MOCK_GROUPS_MAP = {
-    SDSU: ['Josh Wong', 'Isaac Otero', 'Kevin Lai', 'Joyce Lai'],
-    IUSM: ['Brian Lin', 'James Lee'],
-    IGSM: ['Jack Zhang', 'Angel Zhang'],
-    "INT'L": ['Brian Lin', 'James Lee', 'Jack Zhang', 'Angel Zhang']
+    sdsu: ['josh wong', 'isaac otero', 'kevin lai', 'joyce lai'],
+    iusm: ['brian lin', 'james lee'],
+    igsm: ['jack zhang', 'angel zhang'],
+    "int'l": ['brian lin', 'james lee', 'jack zhang', 'angel zhang']
 };
 
 describe('getMembersFromGroups', () => {
     it('should return a flat array of members for given group names', () => {
-        const groupNames = ['SDSU', 'IUSM'];
+        const groupNames = ['sdsu', 'iusm'];
 
         jest.mock('../src/main/propertiesService', () => ({
             loadMapFromScriptProperties: jest.fn(() => MOCK_GROUPS_MAP)
@@ -503,7 +503,7 @@ describe('getMembersFromGroups', () => {
         const { getMembersFromGroups } = require("../src/main/groups");
 
         const result = getMembersFromGroups(groupNames);
-        expect(result).toEqual(['Josh Wong', 'Isaac Otero', 'Kevin Lai', 'Joyce Lai', 'Brian Lin', 'James Lee']);
+        expect(result).toEqual(['josh wong', 'isaac otero', 'kevin lai', 'joyce lai', 'brian lin', 'james lee']);
     });
 
     it('should return an empty array when no groups are provided', () => {
@@ -520,7 +520,7 @@ describe('getMembersFromGroups', () => {
     });
 
     it('should skip groups not found in GROUPS_MAP', () => {
-        const groupNames = ['IGSM', 'KALEO'];
+        const groupNames = ['igsm', 'kaleo'];
 
         jest.mock('../src/main/propertiesService', () => ({
             loadMapFromScriptProperties: jest.fn(() => MOCK_GROUPS_MAP)
@@ -529,11 +529,11 @@ describe('getMembersFromGroups', () => {
         const { getMembersFromGroups } = require("../src/main/groups");
 
         const result = getMembersFromGroups(groupNames);
-        expect(result).toEqual(['Jack Zhang', 'Angel Zhang']);
+        expect(result).toEqual(['jack zhang', 'angel zhang']);
     });
 
     it('should handle duplicate group names', () => {
-        const groupNames = ['IUSM', 'IUSM'];
+        const groupNames = ['iusm', 'iusm'];
 
         jest.mock('../src/main/propertiesService', () => ({
             loadMapFromScriptProperties: jest.fn(() => MOCK_GROUPS_MAP)
@@ -542,11 +542,11 @@ describe('getMembersFromGroups', () => {
         const { getMembersFromGroups } = require("../src/main/groups");
 
         const result = getMembersFromGroups(groupNames);
-        expect(result).toEqual(['Brian Lin', 'James Lee']);
+        expect(result).toEqual(['brian lin', 'james lee']);
     });
 
     it('should return an empty array if no group names match', () => {
-        const groupNames = ['KALEO', 'IMPACT'];
+        const groupNames = ['kaleo', 'impact'];
 
         // Mock GROUPS_MAP in your test environment if needed
         jest.mock('../src/main/propertiesService', () => ({

--- a/__test__/groups.test.ts
+++ b/__test__/groups.test.ts
@@ -543,13 +543,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson", "Sophia Martinez", "Emma Anderson", "Casey Morgan"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown"],
-            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown", "Charlie Davis", "Emily Clark", "William Johnson", "Olivia Wilson"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson", "sophia martinez", "emma anderson", "casey morgan"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown", "robert brown"],
+            college: ["john doe", "jane smith", "alice johnson", "bob brown", "robert brown", "charlie davis", "emily clark", "william johnson", "olivia wilson"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));
@@ -594,13 +594,13 @@ describe("loadGroupsFromOnestopIntoScriptProperties", () => {
         loadGroupsFromOnestopIntoScriptProperties();
 
         const expectedMap: GroupsMap = {
-            HG1: ["John Doe", "Jane Smith"],
-            HG2: ["Alice Johnson", "Bob Brown"],
-            SDSU: ["Charlie Davis", "Emily Clark"],
-            A2K: ["Frank Miller", "Grace Wilson"],
-            Community: ["Frank Miller", "Grace Wilson"],
-            UCSD: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown"],
-            College: ["John Doe", "Jane Smith", "Alice Johnson", "Bob Brown", "Robert Brown", "Charlie Davis", "Emily Clark"],
+            hg1: ["john doe", "jane smith"],
+            hg2: ["alice johnson", "bob brown"],
+            sdsu: ["charlie davis", "emily clark"],
+            a2k: ["frank miller", "grace wilson"],
+            community: ["frank miller", "grace wilson"],
+            ucsd: ["john doe", "jane smith", "alice johnson", "bob brown", "robert brown"],
+            college: ["john doe", "jane smith", "alice johnson", "bob brown", "robert brown", "charlie davis", "emily clark"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalledWith("GROUPS_MAP", JSON.stringify(expectedMap));

--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -5,6 +5,7 @@ global.PropertiesService = PropertiesService;
 global.SpreadsheetApp = SpreadsheetApp;
 
 import { getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, Mock } from './testUtils';
+import { PersonAliasClashError } from '../src/main/error/personAliasClashError';
 
 const NAME_COLUMN_INDEX: number = 0;
 const GENDER_COLUMN_INDEX: number = 1;
@@ -73,28 +74,28 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         const receivedAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
 
         const expectedMemberMap: MemberMap = {
-            "John Doe": {name: "John Doe", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
-            "James Brown": {name: "James Brown", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
-            "Mary Brown": {name: "Mary Brown", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
-            "Robert White": {name: "Robert White", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
-            "Emily White": {name: "Emily White", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
+            "john doe": {name: "john doe", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
+            "james brown": {name: "james brown", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
+            "mary brown": {name: "mary brown", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
+            "robert white": {name: "robert white", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
+            "emily white": {name: "emily white", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
         };
 
         const expectedAliasMap: AliasMap = {
-            "John": ["John Doe"],
-            "John D": ["John Doe"],
-            "James": ["James Brown"],
-            "James B": ["James Brown"],
-            "Mary": ["Mary Brown"],
-            "Mary B": ["Mary Brown"],
-            "Robert": ["Robert White"],
-            "Robert W": ["Robert White"],
-            "Emily": ["Emily White"],
-            "Emily W": ["Emily White"],
-            "James/Mary": ["James Brown", "Mary Brown"],
-            "Browns": ["James Brown", "Mary Brown"],
-            "Robert/Emily": ["Robert White", "Emily White"],
-            "Whites": ["Robert White", "Emily White"],
+            "john": ["john doe"],
+            "john d": ["john doe"],
+            "james": ["james brown"],
+            "james b": ["james brown"],
+            "mary": ["mary brown"],
+            "mary b": ["mary brown"],
+            "robert": ["robert white"],
+            "robert w": ["robert white"],
+            "emily": ["emily white"],
+            "emily w": ["emily white"],
+            "james/mary": ["james brown", "mary brown"],
+            "browns": ["james brown", "mary brown"],
+            "robert/emily": ["robert white", "emily white"],
+            "whites": ["robert white", "emily white"],
         };
 
         expect(setScriptPropertyMock).toHaveBeenCalled();
@@ -134,10 +135,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
 
         const expectedAliasMap: AliasMap = {
-            "John": ["John Doe"],
-            "John D": ["John Doe"],
-            "James": ["James Brown"],
-            "James B": ["James Brown"],
+            "john": ["john doe"],
+            "john d": ["john doe"],
+            "james": ["james brown"],
+            "james b": ["james brown"],
         };
 
         jest.mock("../src/main/scan", () => ({
@@ -163,7 +164,7 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         expect(membersAliases).toStrictEqual(expectedAliasMap);
     });
 
-    it("should map an alternate name to multiple people when multiple people share the same alternate name", () => {
+    it("should throw an error when multiple people share the same alternate name", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
         membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
         membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
@@ -171,12 +172,6 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
-
-        const expectedAliasMap: AliasMap = {
-            "John": ["John Doe", "John Brown"],
-            "John D": ["John Doe"],
-            "John B": ["John Brown"],
-        };
 
         jest.mock("../src/main/scan", () => ({
             getCellValues: jest.fn()
@@ -189,16 +184,8 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
             setScriptProperty: jest.fn(),
         }));
 
-        const mergeAliasMapsMock: Mock = jest.fn(() => expectedAliasMap);
-        jest.mock("../src/main/aliases", () => ({
-            mergeAliasMaps: mergeAliasMapsMock,
-        }));
-
         const { loadMembersFromOnestopIntoScriptProperties } = require('../src/main/members');
-        const membersAliases: AliasMap = loadMembersFromOnestopIntoScriptProperties();
-
-        expect(mergeAliasMapsMock).toHaveBeenCalledWith(expectedAliasMap, {});
-        expect(membersAliases).toStrictEqual(expectedAliasMap);
+        expect(() => loadMembersFromOnestopIntoScriptProperties()).toThrow(new PersonAliasClashError('Multiple members have the alternate name john'));
     });
 
     it("should map an alias to both a person and a couple when a person's alternate name is the same as a couple's alias", () => {
@@ -215,27 +202,27 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "JM"];
 
         const expectedMembersAliasMap: AliasMap = {
-            "John": ["John Miller"],
-            "John M": ["John Miller"],
-            "JM": ["John Miller"],
-            "James": ["James Brown"],
-            "James B": ["James Brown"],
-            "Mary": ["Mary Brown"],
-            "Mary B": ["Mary Brown"]
+            "john": ["john miller"],
+            "john m": ["john miller"],
+            "jm": ["john miller"],
+            "james": ["james brown"],
+            "james b": ["james brown"],
+            "mary": ["mary brown"],
+            "mary b": ["mary brown"]
         };
 
         const expectedCouplesAliasMap: AliasMap = {
-            "JM": ["James Brown", "Mary Brown"],
+            "jm": ["james brown", "mary brown"],
         };
 
         const expectedAliasMap: AliasMap = {
-            "John": ["John Miller"],
-            "John M": ["John Miller"],
-            "JM": ["John Miller", "James Brown", "Mary Brown"],
-            "James": ["James Brown"],
-            "James B": ["James Brown"],
-            "Mary": ["Mary Brown"],
-            "Mary B": ["Mary Brown"],
+            "john": ["john miller"],
+            "john m": ["john miller"],
+            "jm": ["john miller", "james brown", "mary brown"],
+            "james": ["james brown"],
+            "james b": ["james brown"],
+            "mary": ["mary brown"],
+            "mary b": ["mary brown"],
         };
 
         jest.mock("../src/main/scan", () => ({

--- a/__test__/people.test.ts
+++ b/__test__/people.test.ts
@@ -1,0 +1,21 @@
+import { PropertiesService } from 'gasmask';
+global.PropertiesService = PropertiesService;
+import {normalizePersonName} from "../src/main/people";
+
+describe("normalizePersonName", () => {
+    it("should allow empty", () => {
+        expect(normalizePersonName("")).toEqual("");
+    });
+    it("should make lowercase", () => {
+        expect(normalizePersonName("HUDSON TAYLOR")).toEqual("hudson taylor");
+    });
+    it("should remove extra whitespace", () => {
+        expect(normalizePersonName("  adoniram   judson  ")).toEqual("adoniram judson");
+    });
+    it("should remove parentheses", () => {
+        expect(normalizePersonName("brian (jun) lin (sd)")).toEqual("brian lin");
+    });
+    it("should not remove middle names", () => {
+        expect(normalizePersonName("jonathan koby cayaban")).toEqual("jonathan koby cayaban");
+    });
+});

--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -9,6 +9,7 @@ import { RowMissingIdError } from '../src/main/error/rowMissingIdError';
 import { getRandomlyGeneratedByteArray, getRandomlyGeneratedMember, getRandomlyGeneratedMetadata, getRandomlyGeneratedRange, getRandomlyGeneratedRoleTodoIdMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedText, Mock } from './testUtils';
 import randomstring from "randomstring";
 import { RowBasecampMappingMissingError } from '../src/main/error/rowBasecampMappingMissingError';
+import { normalizePersonName } from '../src/main/people';
 
 describe("getMetadata", () => {
     it("should return the Metadata object when a single Metadata object is present", () => {
@@ -110,12 +111,12 @@ describe('getAttendeesFromRow', () => {
         row.who = "IGSM";
 
         const MOCK_GROUPS_MAP = {
-            IGSM: ['Jack Zhang', 'Angel Zhang'],
+            igsm: ['jack zhang', 'angel zhang'],
         };
 
         const MOCK_MEMBER_MAP = {
-            "Jack Zhang": {"gender": "Male"},
-            "Angel Zhang": {"gender": "Female"}
+            "jack zhang": {"gender": "Male"},
+            "angel zhang": {"gender": "Female"}
         };
 
         jest.mock('../src/main/propertiesService', () => ({
@@ -133,7 +134,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Jack Zhang', 'Angel Zhang']);
+        expect(result).toEqual(['jack zhang', 'angel zhang']);
     });
 
     it('should return all specified domain members when no ministry names are present', () => {
@@ -143,15 +144,15 @@ describe('getAttendeesFromRow', () => {
 
         // Mocked GROUPS_MAP
         const MOCK_GROUPS_MAP = {
-            "INT'L": ['Brian Lin', 'James Lee', 'Jack Zhang', 'Angel Zhang'],
+            "int'l": ['brian lin', 'james lee', 'jack zhang', 'angel zhang'],
         };
 
         // Mocked MEMBER MAP
         const MOCK_MEMBER_MAP = {
-            "Brian Lin": {"gender": "Male"},
-            "James Lee": {"gender": "Male"},
-            "Jack Zhang": {"gender": "Male"},
-            "Angel Zhang": {"gender": "Female"}
+            "brian lin": {"gender": "Male"},
+            "james lee": {"gender": "Male"},
+            "jack zhang": {"gender": "Male"},
+            "angel zhang": {"gender": "Female"}
         };
 
         jest.mock('../src/main/propertiesService', () => ({
@@ -169,7 +170,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Brian Lin', 'James Lee', 'Jack Zhang', 'Angel Zhang']);
+        expect(result).toEqual(['brian lin', 'james lee', 'jack zhang', 'angel zhang']);
     });
 
     it('should not throw an error when both ministry and domain names are missing', () => {
@@ -199,11 +200,11 @@ describe('getAttendeesFromRow', () => {
         row.who = "IGSM, Bros";
 
         const MOCK_GROUPS_MAP = {
-            IGSM: ['Jack Zhang', 'Angel Zhang'],
+            igsm: ['jack zhang', 'angel zhang'],
         };
 
         const MOCK_MEMBER_MAP = {
-            "Jack Zhang": {"gender": "Male"},
+            "jack zhang": {"gender": "Male"},
         };
 
         jest.mock('../src/main/propertiesService', () => ({
@@ -221,7 +222,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Jack Zhang']);
+        expect(result).toEqual(['jack zhang']);
     });
 
     it('should apply any filters present in the domain column', () => {
@@ -230,12 +231,12 @@ describe('getAttendeesFromRow', () => {
         row.who = "";
 
         const MOCK_GROUPS_MAP = {
-            COLLEGE: ['Andrew Chan', 'Janice Chan', 'Josh Wong', 'Isaac Otero', 'Kevin Lai', 'Joyce Lai', 'Brian Lin', 'James Lee'],
+            college: ['andrew chan', 'janice chan', 'josh wong', 'isaac otero', 'kevin lai', 'joyce lai', 'brian lin', 'james lee'],
         };
 
         const MOCK_MEMBER_MAP = {
-            "Janice Chan": {"gender": "Female"},
-            "Joyce Lai": {"gender": "Female"},
+            "janice chan": {"gender": "Female"},
+            "joyce lai": {"gender": "Female"},
         };
 
         jest.mock('../src/main/propertiesService', () => ({
@@ -253,7 +254,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Janice Chan', 'Joyce Lai']);
+        expect(result).toEqual(['janice chan', 'joyce lai']);
     });
 
     it('should filter the domain using filters from the ministry column if there are no ministry groups present in the ministry column', () => {
@@ -263,14 +264,14 @@ describe('getAttendeesFromRow', () => {
 
         // Mocked GROUPS_MAP
         const MOCK_GROUPS_MAP = {
-            CHURCHWIDE: ['Andrew Chan', 'Janice Chan', 'Josh Wong', 'Isaac Otero', 'Kevin Lai', 'Joyce Lai', 'Brian Lin', 'James Lee', 'Brian Lin', 'James Lee', 'Jack Zhang', 'Angel Zhang'],
+            churchwide: ['andrew chan', 'janice chan', 'josh wong', 'isaac otero', 'kevin lai', 'joyce lai', 'brian lin', 'james lee', 'brian lin', 'james lee', 'jack zhang', 'angel zhang'],
         };
 
         // Mocked MEMBER MAP
         const MOCK_MEMBER_MAP = {
-            "Janice Chan": {"gender": "Female"},
-            "Joyce Lai": {"gender": "Female"},
-            "Angel Zhang": {"gender": "Female"}
+            "janice chan": {"gender": "Female"},
+            "joyce lai": {"gender": "Female"},
+            "angel zhang": {"gender": "Female"}
         };
 
         jest.mock('../src/main/propertiesService', () => ({
@@ -291,7 +292,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Janice Chan', 'Joyce Lai', 'Angel Zhang']);
+        expect(result).toEqual(['janice chan', 'joyce lai', 'angel zhang']);
     });
     
 
@@ -326,7 +327,7 @@ describe('getAttendeesFromRow', () => {
 
         const result = getAttendeesFromRow(row);
 
-        expect(result).toEqual(['Kevin Lai', 'Josh Wong', 'Isaac Otero']);
+        expect(result).toEqual(['kevin lai', 'josh wong', 'isaac otero']);
     });
 });
 
@@ -462,20 +463,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": randomstring.generate(),
+            "jane smith": randomstring.generate(),
+            "alice johnson": randomstring.generate(),
+            "bob brown": randomstring.generate(),
         };
 
         jest.mock("../src/main/members", () => ({
@@ -488,12 +489,13 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["John Doe"], peopleToBasecampIdMap["Jane Smith"]] },
-            { role: "Tech", helperIds: [peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["Bob Brown"]] }
+            { role: "Food", helperIds: [peopleToBasecampIdMap["john doe"], peopleToBasecampIdMap["jane smith"]] },
+            { role: "Tech", helperIds: [peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["bob brown"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -510,20 +512,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": randomstring.generate(),
+            "jane smith": randomstring.generate(),
+            "alice johnson": randomstring.generate(),
+            "bob brown": randomstring.generate(),
         };
 
         jest.mock("../src/main/members", () => ({
@@ -532,15 +534,16 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/groups", () => ({
-            GROUPS_MAP: { "UCSD": ["John Doe", "Bob Brown"] },
+            GROUPS_MAP: { "ucsd": ["john doe", "bob brown"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["Jane Smith"], peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["John Doe"], peopleToBasecampIdMap["Bob Brown"]] }
+            { role: "Food", helperIds: [peopleToBasecampIdMap["jane smith"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["john doe"], peopleToBasecampIdMap["bob brown"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -557,20 +560,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": "johndoeid",
+            "jane smith": "jsid",
+            "alice johnson": "ajid",
+            "bob brown": "bbid",
         };
 
         jest.mock("../src/main/members", () => ({
@@ -578,19 +581,20 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/aliases", () => ({
-            ALIASES_MAP: { "John/Jane": ["John Doe", "Jane Smith"] },
+            ALIASES_MAP: { "john/jane": ["john doe", "jane smith"] },
         }));
 
         jest.mock("../src/main/groups", () => ({
-            GROUPS_MAP: { "UCSD": ["John Doe", "Bob Brown"] },
+            GROUPS_MAP: { "ucsd": ["john doe", "bob brown"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["John Doe"], peopleToBasecampIdMap["Jane Smith"], peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["Bob Brown"]] }
+            { role: "Food", helperIds: [peopleToBasecampIdMap["john doe"], peopleToBasecampIdMap["jane smith"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["bob brown"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -607,20 +611,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": randomstring.generate(),
+            "jane smith": randomstring.generate(),
+            "alice johnson": randomstring.generate(),
+            "bob brown": randomstring.generate(),
         };
 
         jest.mock("../src/main/members", () => ({
@@ -629,15 +633,16 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/groups", () => ({
-            GROUPS_MAP: { "UCSD": ["John Doe", "Jane Smith"] },
+            GROUPS_MAP: { "ucsd": ["john doe", "jane smith"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["Bob Brown"], peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["John Doe"]] }
+            { role: "Food", helperIds: [peopleToBasecampIdMap["bob brown"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["john doe"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -654,20 +659,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": randomstring.generate(),
+            "jane smith": randomstring.generate(),
+            "alice johnson": randomstring.generate(),
+            "bob brown": randomstring.generate(),
         };
 
         jest.mock("../src/main/members", () => ({
@@ -676,15 +681,16 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/groups", () => ({
-            GROUPS_MAP: { "UCSD": ["John Doe", "Alice Johnson"] },
+            GROUPS_MAP: { "ucsd": ["john doe", "alice johnson"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["Bob Brown"], peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["John Doe"]] }
+            { role: "Food", helperIds: [peopleToBasecampIdMap["bob brown"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["john doe"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -701,20 +707,20 @@ describe("getHelperGroups", () => {
         rowMock.helpers.value = helpersValueMock;
 
         const memberMapMock: MemberMap = {};
-        memberMapMock["John Doe"] = getRandomlyGeneratedMember();
-        memberMapMock["John Doe"].gender = "Male";
-        memberMapMock["Jane Smith"] = getRandomlyGeneratedMember();
-        memberMapMock["Jane Smith"].gender = "Female";
-        memberMapMock["Alice Johnson"] = getRandomlyGeneratedMember();
-        memberMapMock["Alice Johnson"].gender = "Female";
-        memberMapMock["Bob Brown"] = getRandomlyGeneratedMember();
-        memberMapMock["Bob Brown"].gender = "Male";
+        memberMapMock["john doe"] = getRandomlyGeneratedMember();
+        memberMapMock["john doe"].gender = "Male";
+        memberMapMock["jane smith"] = getRandomlyGeneratedMember();
+        memberMapMock["jane smith"].gender = "Female";
+        memberMapMock["alice johnson"] = getRandomlyGeneratedMember();
+        memberMapMock["alice johnson"].gender = "Female";
+        memberMapMock["bob brown"] = getRandomlyGeneratedMember();
+        memberMapMock["bob brown"].gender = "Male";
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
-            "John Doe": randomstring.generate(),
-            "Jane Smith": randomstring.generate(),
-            "Alice Johnson": randomstring.generate(),
-            "Bob Brown": randomstring.generate(),
+            "john doe": randomstring.generate(),
+            "jane smith": randomstring.generate(),
+            "alice johnson": randomstring.generate(),
+            "bob brown": randomstring.generate(),
         };
 
         jest.mock("../src/main/members", () => ({
@@ -727,11 +733,12 @@ describe("getHelperGroups", () => {
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
         }));
 
         const expectedHelperGroups: HelperGroup[] = [
-            { role: undefined, helperIds: [peopleToBasecampIdMap["John Doe"], peopleToBasecampIdMap["Jane Smith"], peopleToBasecampIdMap["Alice Johnson"], peopleToBasecampIdMap["Bob Brown"]] }
+            { role: undefined, helperIds: [peopleToBasecampIdMap["john doe"], peopleToBasecampIdMap["jane smith"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["bob brown"]] }
         ];
 
         const { getHelperGroups } = require("../src/main/row");
@@ -809,11 +816,12 @@ describe("hasBasecampAttendees", () => {
         rowMock.helpers.value = "Jane Smith, Alice Johnson";
 
         jest.mock("../src/main/groups", () => ({
-            GROUP_NAMES: ["UCSD"],
-            GROUPS_MAP: { "UCSD": ["John Doe", "Jane Smith", "Alice Johnson"] },
+            GROUP_NAMES: ["ucsd"],
+            GROUPS_MAP: { "ucsd": ["john doe", "jane smith", "alice johnson"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn(() => randomstring.generate()),
         }));
 
@@ -832,11 +840,12 @@ describe("hasBasecampAttendees", () => {
         rowMock.helpers.value = "";
 
         jest.mock("../src/main/groups", () => ({
-            GROUP_NAMES: ["UCSD"],
-            GROUPS_MAP: { "UCSD": ["John Doe", "Jane Smith", "Alice Johnson"] },
+            GROUP_NAMES: ["ucsd"],
+            GROUPS_MAP: { "ucsd": ["john doe", "jane smith", "alice johnson"] },
         }));
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn(() => randomstring.generate()),
         }));
 
@@ -858,18 +867,19 @@ describe("getScheduleEntryRequestForRow", () => {
         rowMock.helpers.value = "Jane Smith, Alice Johnson";
 
         jest.mock("../src/main/groups", () => ({
-            GROUP_NAMES: ["UCSD"],
-            GROUPS_MAP: { "UCSD": ["John Doe", "Jane Smith", "Alice Johnson"] },
-            getMembersFromGroups: jest.fn(() => ["John Doe", "Jane Smith", "Alice Johnson"]),
+            GROUP_NAMES: ["ucsd"],
+            GROUPS_MAP: { "ucsd": ["john doe", "jane smith", "alice johnson"] },
+            getMembersFromGroups: jest.fn(() => ["john doe", "jane smith", "alice johnson"]),
         }));
 
         const PEOPLE_MAP: { [name: string]: string } = {
-            "John Doe": "1",
-            "Jane Smith": "2",
-            "Alice Johnson": "3",
+            "john doe": "1",
+            "jane smith": "2",
+            "alice johnson": "3",
         };  
 
         jest.mock("../src/main/people", () => ({
+            normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
             getPersonId: jest.fn((personName) => PEOPLE_MAP.hasOwnProperty(personName) ? PEOPLE_MAP[personName] : randomstring.generate()),
         }));
 
@@ -885,8 +895,8 @@ describe("getScheduleEntryRequestForRow", () => {
         expect(scheduleEntryRequest.description).toContain(rowMock.inCharge.value);
         expect(scheduleEntryRequest.description).toContain(rowMock.helpers.value);
         rowMock.notes.tokens.forEach((token) => expect(scheduleEntryRequest.description).toContain(token.value));
-        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["John Doe"]);
-        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["Jane Smith"]);
-        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["Alice Johnson"]);
+        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["john doe"]);
+        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["jane smith"]);
+        expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["alice johnson"]);
     });
 });

--- a/__test__/validation.test.ts
+++ b/__test__/validation.test.ts
@@ -16,7 +16,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "GROUPS_MAP") {
                     return {
-                        "HG2": ['Andrew Chan', 'Janice Chan']
+                        "hg2": ['andrew chan', 'janice chan']
                     }
                 } 
                 return {};
@@ -32,7 +32,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "ALIASES_MAP") {
                     return {
-                        "Andrew/Janice": ['Andrew Chan', 'Janice Chan']
+                        "andrew/janice": ['andrew chan', 'janice chan']
                     }
                 } 
                 return {};
@@ -48,7 +48,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"}
+                        "andrew chan": {"gender": "Male"}
                     }
                 } 
                 return {};
@@ -64,7 +64,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"}
+                        "andrew chan": {"gender": "Male"}
                     }
                 } 
                 return {};
@@ -80,7 +80,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"}
+                        "andrew chan": {"gender": "Male"}
                     }
                 } 
                 return {};
@@ -96,7 +96,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "GROUPS_MAP") {
                     return {
-                        "HG2": ['Andrew Chan', 'Janice Chan']
+                        "hg2": ['andrew chan', 'janice chan']
                     }
                 } 
                 return {};
@@ -112,9 +112,9 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"},
-                        "Janice Chan": {"gender": "Female"},
-                        "Josh Wong": {"gender": "Male"}
+                        "andrew chan": {"gender": "Male"},
+                        "janice chan": {"gender": "Female"},
+                        "josh wong": {"gender": "Male"}
                     }
                 } 
                 return {};
@@ -130,9 +130,9 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"},
-                        "Janice Chan": {"gender": "Female"},
-                        "Josh Wong": {"gender": "Male"}
+                        "andrew chan": {"gender": "Male"},
+                        "janice chan": {"gender": "Female"},
+                        "josh wong": {"gender": "Male"}
                     }
                 } 
                 return {};
@@ -148,8 +148,8 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"},
-                        "Janice Chan": {"gender": "Female"},
+                        "andrew chan": {"gender": "Male"},
+                        "janice chan": {"gender": "Female"},
                     }
                 } 
                 return {};
@@ -165,16 +165,16 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "GROUPS_MAP") {
                     return {
-                        "SDSU": ['Josh Wong']
+                        "sdsu": ['josh wong']
                     }
                 } else if (key === "ALIASES_MAP") {
                     return {
-                        "Jack/Angel": ['Jack Zhang', 'Angel Zhang']
+                        "jack/angel": ['jack zhang', 'angel zhang']
                     }
                 } else if (key === "MEMBER_MAP") {
                     return {
-                        "Andrew Chan": {"gender": "Male"},
-                        "Janice Chan": {"gender": "Female"},
+                        "andrew chan": {"gender": "Male"},
+                        "janice chan": {"gender": "Female"},
                     }
                 } 
                 return {};
@@ -190,7 +190,7 @@ describe("isHelperCellValid", () => {
             loadMapFromScriptProperties: jest.fn((key: string) => {
                 if (key === "GROUPS_MAP") {
                     return {
-                        "SDSU": ['Josh Wong']
+                        "sdsu": ['josh wong']
                     }
                 }
                 return {};

--- a/src/main/error/personAliasClashError.ts
+++ b/src/main/error/personAliasClashError.ts
@@ -1,0 +1,9 @@
+export class PersonAliasClashError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PersonAliasClashError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, PersonAliasClashError.prototype);
+    }
+}

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -11,14 +11,16 @@ const SIS_GENDER: string = "Female";
 
 // Maps a filter's name on the Onestop to its corresponding filter function
 const FILTER_MAP: FilterMap = {
-    Bros: brosFilter, 
-    Sis: sisFilter,
-    Married: marriedFilter,
-    Parents: parentsFilter,
-    Moms: momsFilter,
-    Dads: dadsFilter,
-    "Minus Moms": minusMomsFilter,
-    "Minus Dads": minusDadsFilter,
+    bros: brosFilter, 
+    brothers: brosFilter,
+    sis: sisFilter,
+    sisters: sisFilter,
+    married: marriedFilter,
+    parents: parentsFilter,
+    moms: momsFilter,
+    dads: dadsFilter,
+    "minus moms": minusMomsFilter,
+    "minus dads": minusDadsFilter,
 };
 
 /** Removes all filters from a string
@@ -27,12 +29,12 @@ const FILTER_MAP: FilterMap = {
  * @returns modified string with filters removed as well as the array of removed filters
  */
 export function removeFilters(stringWithFilters: string): { stringWithoutFilters: string, removedFilters: string[] } {
-    if(!containsFilter(stringWithFilters)) {
+    if(!containsFilter(stringWithFilters.toLowerCase())) {
         return { stringWithoutFilters: stringWithFilters, removedFilters: [] };
     }
 
     const filters: string[] = Object.keys(FILTER_MAP);
-    let finalString = stringWithFilters;
+    let finalString = stringWithFilters.toLowerCase();
     const removedFilters: string[] = [];
     for(const filter of filters) {
         if(finalString.includes(filter)) {
@@ -51,7 +53,7 @@ export function removeFilters(stringWithFilters: string): { stringWithoutFilters
  * @returns boolean indicating whether the provided string contains a filter
  */
 export function containsFilter(stringToCheck: string): boolean {
-    return Object.keys(FILTER_MAP).some((filterName) => stringToCheck.includes(filterName));
+    return Object.keys(FILTER_MAP).some((filterName) => stringToCheck.toLowerCase().includes(filterName));
 }
 
 /**
@@ -61,7 +63,7 @@ export function containsFilter(stringToCheck: string): boolean {
  * @returns boolean representing whether the given string has a corresponding filter
  */
 export function isFilter(potentialFilter: string): boolean {
-    return FILTER_MAP.hasOwnProperty(potentialFilter);
+    return FILTER_MAP.hasOwnProperty(potentialFilter.toLowerCase());
 }
 
 /**
@@ -100,7 +102,7 @@ function getCombinedFilter(filterList: string[]): FilterFunction {
 }
 
 function getFilters(filterList: string[]): string[] {
-    return filterList.map(filterName => filterName.trim()).filter(filterName => filterName !== "");
+    return filterList.map(filterName => filterName.toLowerCase().trim()).filter(filterName => filterName !== "");
 }
 
 function validMemberFilter(memberName: string): boolean {

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -202,7 +202,7 @@ function getSupergroupGroupAliases(rowValues: any[]): string[] {
 
 function getSupergroupAdditionalMembers(rowValues: any[]): string[] {
     const supergroupAdditionalMembersList: string = rowValues[SUPERGROUP_ADDITIONAL_MEMBERS_COLUMN_INDEX];
-    return supergroupAdditionalMembersList.split(COMMA_DELIMITER).map((memberName) => memberName.trim()).filter((memberName) => memberName !== "");
+    return supergroupAdditionalMembersList.split(COMMA_DELIMITER).map((memberName) => normalizePersonName(memberName)).filter((memberName) => memberName !== "");
 }
 
 function allSubgroupsHaveBeenLoaded(supergroup: Supergroup, loadedGroups: GroupsMap, loadedSupergroups: GroupsMap, allSupergroups: SupergroupMap): boolean {

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -1,4 +1,5 @@
 import { mergeAliasMaps } from "./aliases";
+import { normalizePersonName } from "./people";
 import { loadMapFromScriptProperties, setScriptProperty } from "./propertiesService";
 import { getCellValues } from "./scan";
 
@@ -66,7 +67,7 @@ function loadGroupsFromOnestop(): { groupsMap: GroupsMap, groupsAliasMap: AliasM
     // Start at row 1 to skip the table header row
     for(let i = 1; i < cellValues.length; i++) {
         const rowValues: any[] = cellValues[i];
-        const groupName: string = rowValues[GROUP_NAME_COLUMN_INDEX];
+        const groupName: string = rowValues[GROUP_NAME_COLUMN_INDEX].toLowerCase().trim();
         const groupMemberNames: string[] = getGroupMemberNames(rowValues);
         const groupAliases: string[] = getGroupAliases(rowValues);
 
@@ -90,11 +91,11 @@ function loadGroupsFromOnestop(): { groupsMap: GroupsMap, groupsAliasMap: AliasM
 
 function getGroupMemberNames(rowValues: any[]): string[] {
     const groupMemberNameList: string = rowValues[GROUP_MEMBER_NAMES_COLUMN_INDEX];
-    return groupMemberNameList.split(COMMA_DELIMITER).map((name) => name.trim()).filter((name) => name !== "");
+    return groupMemberNameList.split(COMMA_DELIMITER).map((name) => normalizePersonName(name)).filter((name) => name !== "");
 }
 
 function getGroupAliases(rowValues: any[]): string[] {
-    const groupAliasesList: string = rowValues[GROUP_ALIASES_COLUMN_INDEX];
+    const groupAliasesList: string = rowValues[GROUP_ALIASES_COLUMN_INDEX].toLowerCase();
     return groupAliasesList.split(COMMA_DELIMITER).map((alias) => alias.trim()).filter((alias) => alias !== "");
 }
 
@@ -173,7 +174,7 @@ function isSuperGroup(groupName: string, allSupergroups: SupergroupMap): boolean
 }
 
 function constructSupergroup(rowValues: any[]): Supergroup {
-    const supergroupName: string = rowValues[SUPERGROUP_NAME_COLUMN_INDEX];
+    const supergroupName: string = rowValues[SUPERGROUP_NAME_COLUMN_INDEX].toLowerCase().trim();
     const subgroupNames: string[] = getSubgroupNames(rowValues);
     const supergroupAliases: string[] = getSupergroupGroupAliases(rowValues);
     
@@ -185,12 +186,12 @@ function constructSupergroup(rowValues: any[]): Supergroup {
 }
 
 function getSubgroupNames(rowValues: any[]): string[] {
-    const subgroupNameList: string = rowValues[SUBGROUP_COLUMN_INDEX];
+    const subgroupNameList: string = rowValues[SUBGROUP_COLUMN_INDEX].toLowerCase();
     return subgroupNameList.split(COMMA_DELIMITER).map((name) => name.trim()).filter((name) => name !== "");
 }
 
 function getSupergroupGroupAliases(rowValues: any[]): string[] {
-    const supergroupAliasesList: string = rowValues[SUPERGROUP_ALIASES_COLUMN_INDEX];
+    const supergroupAliasesList: string = rowValues[SUPERGROUP_ALIASES_COLUMN_INDEX].toLowerCase();
     return supergroupAliasesList.split(COMMA_DELIMITER).map((alias) => alias.trim()).filter((alias) => alias !== "");
 }
 

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -7,6 +7,7 @@ type PersonNameIdMap = {[key: string]: string};
 
 const PEOPLE_PATH: string = `/projects/${BASECAMP_PROJECT_ID}/people.json`;
 const PEOPLE_MAP_KEY: string = "PEOPLE_MAP";
+const REMOVE_PARENTHESES_REGEX: RegExp = /\(.*?\)/g;
 
 let cachedPersonNameIdMap: PersonNameIdMap | null = null;
 
@@ -93,12 +94,9 @@ function getPersonIdFromCache(personName: string): string | undefined {
 /**
  * Normalizes a person name removing any city in parenthesis if found, and also removes middle names
  * 
- * @param rawPersonName person name that may include city in parenthesis or middle names, e.g. Andrew Chan (Sd)
- * @returns the person's first and last name only, e.g. Andrew Chan
+ * @param rawPersonName person name that may include city in parenthesis, e.g. Andrew Chan (Sd)
+ * @returns the person's name without parentheses
  */
 export function normalizePersonName(rawPersonName: string): string {
-    const parenthesisIndex = rawPersonName.indexOf('(');
-    const nameWithoutParenthesis = parenthesisIndex === -1 ? rawPersonName : rawPersonName.slice(0, parenthesisIndex);
-    const fullName = nameWithoutParenthesis.trim().split(' ');
-    return `${fullName[0]} ${fullName[fullName.length - 1]}`;
+    return rawPersonName.replace(REMOVE_PARENTHESES_REGEX, '').toLowerCase().trim();
 }

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -5,9 +5,11 @@ import { getScriptProperty, setScriptProperty } from "./propertiesService";
 
 type PersonNameIdMap = {[key: string]: string};
 
-const PEOPLE_PATH: string = `/projects/${BASECAMP_PROJECT_ID}/people.json`;
+const PEOPLE_JSON: string = "/people.json";
+const PROJECTS_PATH: string = "/projects/";
 const PEOPLE_MAP_KEY: string = "PEOPLE_MAP";
 const REMOVE_PARENTHESES_REGEX: RegExp = /\(.*?\)/g;
+const REMOVE_EXTRA_WHITESPACE_REGEX: RegExp = /\s+/g;
 
 let cachedPersonNameIdMap: PersonNameIdMap | null = null;
 
@@ -17,7 +19,7 @@ let cachedPersonNameIdMap: PersonNameIdMap | null = null;
  * from the Google Apps Script Developer UI
  */
 export function populatePeopleInDb(): void {
-    const requestUrl: string = getBasecampUrl() + PEOPLE_PATH;
+    const requestUrl: string = getPeoplePath();
     const peopleData: Person[] = sendPaginatedBasecampGetRequest(requestUrl) as Person[];
 
     // Reduce all of the people to a single map
@@ -29,6 +31,10 @@ export function populatePeopleInDb(): void {
 
     setScriptProperty(PEOPLE_MAP_KEY, JSON.stringify(personNameIdMap));
     cachedPersonNameIdMap = personNameIdMap;
+}
+
+function getPeoplePath(): string {
+    return getBasecampUrl() + PROJECTS_PATH + BASECAMP_PROJECT_ID + PEOPLE_JSON;
 }
 
 /**
@@ -98,5 +104,7 @@ function getPersonIdFromCache(personName: string): string | undefined {
  * @returns the person's name without parentheses
  */
 export function normalizePersonName(rawPersonName: string): string {
-    return rawPersonName.replace(REMOVE_PARENTHESES_REGEX, '').toLowerCase().trim();
+    const withoutParentheses: string = rawPersonName.replace(REMOVE_PARENTHESES_REGEX, '');
+    const withoutExtraWhitespace: string = withoutParentheses.replace(REMOVE_EXTRA_WHITESPACE_REGEX, ' ');
+    return withoutExtraWhitespace.toLowerCase().trim();
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -578,7 +578,7 @@ function getMinistryNames(row: Row): string[] {
 function getMinistryFilters(row: Row): string[] {
     return splitWhoColumn(row)
     .map(name => name.toLowerCase().trim())
-    .filter(value => isFilter(value));;
+    .filter(value => isFilter(value));
 }
 
 /**

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -46,6 +46,5 @@ function isHelperTokenValid(helperTokenWithFilters: string): boolean {
 }
 
 function normalizeHelper(helper: string): string {
-    // todo: make the whole helper input lowercase; but need to make all the maps lowercase too then to make it work
     return helper.replace(STAFF_REGEX, '').toLowerCase().trim();
 }

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -47,5 +47,5 @@ function isHelperTokenValid(helperTokenWithFilters: string): boolean {
 
 function normalizeHelper(helper: string): string {
     // todo: make the whole helper input lowercase; but need to make all the maps lowercase too then to make it work
-    return helper.replace(STAFF_REGEX, '').trim();
+    return helper.replace(STAFF_REGEX, '').toLowerCase().trim();
 }


### PR DESCRIPTION
Normalize inputs for case insensitivity and with extra whitespace, parentheses removed. 

Additional unrelated changes/bug fixes:
- fix usage of `BASECAMP_PROJECT_ID` in people.ts, after change to how the configs are loaded
- no longer allow the same name alias for multiple ppl when loading from the onestop