### PR TITLE
Todo links in event description

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -2,19 +2,19 @@ import { Logger } from 'gasmask';
 global.Logger = Logger;
 
 import randomstring from "randomstring";
-import { getRandomlyGeneratedRoleRequestMap, getRandomlyGeneratedRoleTodoIdMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedScheduleEntry, getRandomlyGeneratedScheduleEntryIdentifier, getRandomlyGeneratedScheduleIdentifier, Mock } from "./testUtils";
+import { getRandomlyGeneratedRoleRequestMap, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedScheduleEntry, getRandomlyGeneratedScheduleEntryIdentifier, getRandomlyGeneratedScheduleIdentifier, Mock } from "./testUtils";
 
 describe("importOnestopToBasecamp", () => {
     it("should create new Todos and Schedule Entries when a row is new", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock1: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
-        const roleTodoIdMapMock1: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
+        const roleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const rowIdMock1: string = randomstring.generate();
         const rowMock2: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
-        const roleTodoIdMapMock2: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
+        const roleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
         const scheduleEntryIdMock2: string = randomstring.generate();
         const rowIdMock2: string = randomstring.generate();
@@ -57,8 +57,8 @@ describe("importOnestopToBasecamp", () => {
         }));
 
         const createNewTodosMock: Mock = jest.fn()
-            .mockReturnValueOnce(roleTodoIdMapMock1)
-            .mockReturnValueOnce(roleTodoIdMapMock2);
+            .mockReturnValueOnce(roleTodoMapMock1)
+            .mockReturnValueOnce(roleTodoMapMock2);
 
         jest.mock("../src/main/todos", () => ({
             createNewTodos: createNewTodosMock,
@@ -89,13 +89,13 @@ describe("importOnestopToBasecamp", () => {
         expect(createNewTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1);
         expect(createScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleIdentifierMock);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(1, rowMock1);
-        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoIdMapMock1, scheduleEntryIdMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1, scheduleEntryIdMock1);
     
         // Asserts for new second row
         expect(createNewTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2);
         expect(createScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryRequestMock2, scheduleIdentifierMock);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(2, rowMock2);
-        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, roleTodoIdMapMock2, scheduleEntryIdMock2);
+        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, roleTodoMapMock2, scheduleEntryIdMock2);
     });
 
     it("should skip existing rows when the row has not changed", () => {
@@ -183,19 +183,19 @@ describe("importOnestopToBasecamp", () => {
         const scheduleEntryIdentifierMock1: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
         const rowIdMock1: string = randomstring.generate();
         const rowMock2: Row = getRandomlyGeneratedRow();
-        const lastSavedRoleTodoIdMapMock1: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const newRoleTodoIdMapMock1: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const existingRoleTodoIdMapMock1: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const updatedRoleTodoIdMapMock1: RoleTodoIdMap = {...existingRoleTodoIdMapMock1, ...newRoleTodoIdMapMock1};
+        const lastSavedRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoIdMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
         const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
         const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
         const scheduleEntryIdMock2: string = randomstring.generate();
         const scheduleEntryIdentifierMock2: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
         const rowIdMock2: string = randomstring.generate();
-        const lastSavedRoleTodoIdMapMock2: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const newRoleTodoIdMapMock2: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const existingRoleTodoIdMapMock2: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
-        const updatedRoleTodoIdMapMock2: RoleTodoIdMap = {...existingRoleTodoIdMapMock2, ...newRoleTodoIdMapMock2};
+        const lastSavedRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoMapMock2: RoleTodoMap = {...existingRoleTodoMapMock2, ...newRoleTodoMapMock2};
         const documentPropertiesMock: DocumentProperties = {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
@@ -225,8 +225,8 @@ describe("importOnestopToBasecamp", () => {
             .mockReturnValueOnce(rowIdMock1)
             .mockReturnValueOnce(rowIdMock2);
         const getRoleTodoIdMapMock: Mock = jest.fn()
-            .mockReturnValueOnce(lastSavedRoleTodoIdMapMock1)
-            .mockReturnValueOnce(lastSavedRoleTodoIdMapMock2);
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
         const getSavedScheduleEntryIdMock: Mock = jest.fn()
             .mockReturnValueOnce(scheduleEntryIdMock1)
             .mockReturnValueOnce(scheduleEntryIdMock2);
@@ -244,11 +244,11 @@ describe("importOnestopToBasecamp", () => {
 
         const deleteObsoleteTodosMock: Mock = jest.fn();
         const createTodosForNewRolesMock: Mock = jest.fn()
-            .mockReturnValueOnce(newRoleTodoIdMapMock1)
-            .mockReturnValueOnce(newRoleTodoIdMapMock2);
+            .mockReturnValueOnce(newRoleTodoMapMock1)
+            .mockReturnValueOnce(newRoleTodoMapMock2);
         const updateTodosForExistingRolesMock: Mock = jest.fn()
-            .mockReturnValueOnce(existingRoleTodoIdMapMock1)
-            .mockReturnValueOnce(existingRoleTodoIdMapMock2);
+            .mockReturnValueOnce(existingRoleTodoMapMock1)
+            .mockReturnValueOnce(existingRoleTodoMapMock2);
 
         jest.mock("../src/main/todos", () => ({
             deleteObsoleteTodos: deleteObsoleteTodosMock,
@@ -283,19 +283,19 @@ describe("importOnestopToBasecamp", () => {
 
         // Asserts for changed first row
         expect(hasChangedMock).toHaveBeenNthCalledWith(1, rowMock1);
-        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoIdMapMock1);
-        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoIdMapMock1);
-        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoIdMapMock1);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
         expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleEntryIdentifierMock1);
         expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoIdMapMock1, scheduleEntryIdMock1);
     
         // Asserts for changed second row
         expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);
-        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoIdMapMock2);
-        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoIdMapMock2);
-        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoIdMapMock2);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
         expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryRequestMock2, scheduleEntryIdentifierMock2);
-        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoIdMapMock2, scheduleEntryIdMock2);
+        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoMapMock2, scheduleEntryIdMock2);
     });
 
     it("should delete old Todos when a row is deleted", () => {
@@ -339,9 +339,9 @@ describe("importOnestopToBasecamp", () => {
         importOnestopToBasecamp();
 
         expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoMap).map(todo => todo.id));
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(1, rowIdMock1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoMap).map(todo => todo.id));
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(2, rowIdMock2);
     });
 
@@ -394,10 +394,10 @@ describe("importOnestopToBasecamp", () => {
         importOnestopToBasecamp();
 
         expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoMap).map(todo => todo.id));
         expect(deleteScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryIdentifierMock1);
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(1, rowIdMock1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoMap).map(todo => todo.id));
         expect(deleteScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryIdentifierMock2);
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(2, rowIdMock2);
     });
@@ -451,9 +451,9 @@ describe("importOnestopToBasecamp", () => {
         importOnestopToBasecamp();
 
         expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(1, Object.values(rowBasecampMappingMock1.roleTodoMap).map(todo => todo.id));
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(1, rowIdMock1);
-        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoIdMap));
+        expect(deleteTodosMock).toHaveBeenNthCalledWith(2, Object.values(rowBasecampMappingMock2.roleTodoMap).map(todo => todo.id));
         expect(deleteDocumentPropertyMock).toHaveBeenNthCalledWith(2, rowIdMock2);
         expect(deleteScheduleEntryMock).toHaveBeenCalledTimes(0);
     });
@@ -461,7 +461,7 @@ describe("importOnestopToBasecamp", () => {
     it("should save the row even if there are no todos (leads/helpers assigned)", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock1: RoleRequestMap = {};
-        const roleTodoIdMapMock1: RoleTodoIdMap = {};
+        const roleTodoMapMock1: RoleTodoMap = {};
         const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const rowIdMock1: string = randomstring.generate();
@@ -498,7 +498,7 @@ describe("importOnestopToBasecamp", () => {
         }));
 
         const createNewTodosMock: Mock = jest.fn()
-            .mockReturnValueOnce(roleTodoIdMapMock1);
+            .mockReturnValueOnce(roleTodoMapMock1);
 
         jest.mock("../src/main/todos", () => ({
             createNewTodos: createNewTodosMock,
@@ -527,7 +527,7 @@ describe("importOnestopToBasecamp", () => {
         // Asserts for new first row
         expect(createScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleIdentifierMock);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(1, rowMock1);
-        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoIdMapMock1, scheduleEntryIdMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1, scheduleEntryIdMock1);
     
     });
 });

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -186,7 +186,7 @@ describe("importOnestopToBasecamp", () => {
         const lastSavedRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const newRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const existingRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
-        const updatedRoleTodoIdMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
+        const updatedRoleTodoMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
         const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
         const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
         const scheduleEntryIdMock2: string = randomstring.generate();
@@ -224,7 +224,7 @@ describe("importOnestopToBasecamp", () => {
         const getIdMock: Mock = jest.fn()
             .mockReturnValueOnce(rowIdMock1)
             .mockReturnValueOnce(rowIdMock2);
-        const getRoleTodoIdMapMock: Mock = jest.fn()
+        const getRoleTodoMapMock: Mock = jest.fn()
             .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
             .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
         const getSavedScheduleEntryIdMock: Mock = jest.fn()
@@ -238,7 +238,7 @@ describe("importOnestopToBasecamp", () => {
             getScheduleEntryRequestForRow: getScheduleEntryRequestForRowMock,
             saveRow: saveRowMock,
             getId: getIdMock,
-            getRoleTodoIdMap: getRoleTodoIdMapMock,
+            getRoleTodoMap: getRoleTodoMapMock,
             getSavedScheduleEntryId: getSavedScheduleEntryIdMock,
         }));
 
@@ -287,7 +287,7 @@ describe("importOnestopToBasecamp", () => {
         expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
         expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
         expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleEntryIdentifierMock1);
-        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoIdMapMock1, scheduleEntryIdMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoMapMock1, scheduleEntryIdMock1);
     
         // Asserts for changed second row
         expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);

--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -6,7 +6,7 @@ global.PropertiesService = PropertiesService;
 
 import { generateIdForRow, getId, getMetadata, getSavedScheduleEntryId, hasId, saveRow } from "../src/main/row";
 import { RowMissingIdError } from '../src/main/error/rowMissingIdError';
-import { getRandomlyGeneratedByteArray, getRandomlyGeneratedMember, getRandomlyGeneratedMetadata, getRandomlyGeneratedRange, getRandomlyGeneratedRoleTodoIdMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedText, Mock } from './testUtils';
+import { getRandomlyGeneratedByteArray, getRandomlyGeneratedMember, getRandomlyGeneratedMetadata, getRandomlyGeneratedRange, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedText, Mock } from './testUtils';
 import randomstring from "randomstring";
 import { RowBasecampMappingMissingError } from '../src/main/error/rowBasecampMappingMissingError';
 
@@ -380,16 +380,16 @@ describe("saveRow", () => {
         metadataMock.getValue = jest.fn(() => null);
         rowMock.metadata = metadataMock;
 
-        const roleTodoIdMapMock: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
+        const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const scheduleEntryIdMock: string = randomstring.generate();
 
-        expect(() => saveRow(rowMock, roleTodoIdMapMock, scheduleEntryIdMock)).toThrow(RowMissingIdError);
+        expect(() => saveRow(rowMock, roleTodoMapMock, scheduleEntryIdMock)).toThrow(RowMissingIdError);
     });
 
     it("should save the row to the document properties when called", () => {
         const rowMock: Row = getRandomlyGeneratedRow();
         const metadataMock: Metadata = getRandomlyGeneratedMetadata();
-        const roleTodoIdMapMock: RoleTodoIdMap = getRandomlyGeneratedRoleTodoIdMap();
+        const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const scheduleEntryIdMock: string = randomstring.generate();
 
         const rowIdMock: string = randomstring.generate();
@@ -411,7 +411,7 @@ describe("saveRow", () => {
 
         const { saveRow } = require("../src/main/row");
 
-        saveRow(rowMock, roleTodoIdMapMock, scheduleEntryIdMock);
+        saveRow(rowMock, roleTodoMapMock, scheduleEntryIdMock);
 
         expect(setDocumentPropertyMock).toHaveBeenCalledWith(rowIdMock, expect.any(String));
     });

--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -746,7 +746,7 @@ describe("clearAllRowMetadata", () => {
 
 });
 
-describe("getRoleTodoIdMap", () => {
+describe("getRoleTodoMap", () => {
 
 });
 
@@ -856,6 +856,7 @@ describe("getScheduleEntryRequestForRow", () => {
         rowMock.inCharge.value = "John Doe";
         rowMock.helpers = getRandomlyGeneratedText(1);
         rowMock.helpers.value = "Jane Smith, Alice Johnson";
+        const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
 
         jest.mock("../src/main/groups", () => ({
             GROUP_NAMES: ["UCSD"],
@@ -875,7 +876,7 @@ describe("getScheduleEntryRequestForRow", () => {
 
         const { getScheduleEntryRequestForRow } = require("../src/main/row");
 
-        const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(rowMock);
+        const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(rowMock, roleTodoMapMock);
         expect(scheduleEntryRequest).toBeDefined();
         expect(scheduleEntryRequest.summary).toContain("UCSD");
         expect(scheduleEntryRequest.summary).toContain(rowMock.what.value);
@@ -884,6 +885,7 @@ describe("getScheduleEntryRequestForRow", () => {
         rowMock.where.tokens.forEach((token) => expect(scheduleEntryRequest.description).toContain(token.value));
         expect(scheduleEntryRequest.description).toContain(rowMock.inCharge.value);
         expect(scheduleEntryRequest.description).toContain(rowMock.helpers.value);
+        Object.values(roleTodoMapMock).forEach((todo) => expect(scheduleEntryRequest.description).toContain(todo.url));
         rowMock.notes.tokens.forEach((token) => expect(scheduleEntryRequest.description).toContain(token.value));
         expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["John Doe"]);
         expect(scheduleEntryRequest.participant_ids).toContain(PEOPLE_MAP["Jane Smith"]);

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -353,10 +353,10 @@ export function getRandomlyGeneratedScheduleEntry(): BasecampScheduleEntryReques
     }
 }
 
-export function getRandomlyGeneratedRoleTodoIdMap(numRoles: number = 10): RoleTodoIdMap {
-    const roleTodoIdMap: RoleTodoIdMap = {};
+export function getRandomlyGeneratedRoleTodoMap(numRoles: number = 10): RoleTodoMap {
+    const roleTodoIdMap: RoleTodoMap = {};
     for(let i = 0; i < numRoles; i++) {
-        roleTodoIdMap[randomstring.generate()] = randomstring.generate();
+        roleTodoIdMap[randomstring.generate()] = { id: randomstring.generate(), url: randomstring.generate() };
     }
 
     return roleTodoIdMap;
@@ -369,7 +369,7 @@ export function getRandomlyGeneratedByteArray(numBytes: number = 100): Uint8Arra
 export function getRandomlyGeneratedRowBasecampMapping(): RowBasecampMapping {
     return {
         rowHash: randomstring.generate(),
-        roleTodoIdMap: getRandomlyGeneratedRoleTodoIdMap(),
+        roleTodoMap: getRandomlyGeneratedRoleTodoMap(),
         scheduleEntryId: randomstring.generate(),
         tabInfo: { date: new Date() },
     };

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -354,12 +354,12 @@ export function getRandomlyGeneratedScheduleEntry(): BasecampScheduleEntryReques
 }
 
 export function getRandomlyGeneratedRoleTodoMap(numRoles: number = 10): RoleTodoMap {
-    const roleTodoIdMap: RoleTodoMap = {};
+    const roleTodoMap: RoleTodoMap = {};
     for(let i = 0; i < numRoles; i++) {
-        roleTodoIdMap[randomstring.generate()] = { id: randomstring.generate(), url: randomstring.generate() };
+        roleTodoMap[randomstring.generate()] = { id: randomstring.generate(), url: randomstring.generate() };
     }
 
-    return roleTodoIdMap;
+    return roleTodoMap;
 }
 
 export function getRandomlyGeneratedByteArray(numBytes: number = 100): Uint8Array {

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -356,7 +356,7 @@ export function getRandomlyGeneratedScheduleEntry(): BasecampScheduleEntryReques
 export function getRandomlyGeneratedRoleTodoMap(numRoles: number = 10): RoleTodoMap {
     const roleTodoMap: RoleTodoMap = {};
     for(let i = 0; i < numRoles; i++) {
-        roleTodoMap[randomstring.generate()] = { id: randomstring.generate(), url: randomstring.generate() };
+        roleTodoMap[randomstring.generate()] = { id: randomstring.generate(), title: randomstring.generate(), url: randomstring.generate() };
     }
 
     return roleTodoMap;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
-import { getRoleTodoIdMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow } from "./row";
+import { getRoleTodoMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow } from "./row";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
 import { getEventRowsFromSpreadsheet } from "./scan";
 import { createScheduleEntry, deleteScheduleEntry, getDefaultScheduleIdentifier, getScheduleEntryIdentifier, updateScheduleEntry } from "./schedule";
@@ -48,7 +48,7 @@ function processExistingRow(row: Row): void {
 
     if(hasChanged(row)) {
         const updatedRoleTodoMap: RoleTodoMap = handleTodosForExistingRow(row);
-        const scheduleEntryId: string = handleScheduleEntryForExistingRow(row);
+        const scheduleEntryId: string = handleScheduleEntryForExistingRow(row, updatedRoleTodoMap);
 
         saveRow(row, updatedRoleTodoMap, scheduleEntryId);
     }
@@ -56,7 +56,7 @@ function processExistingRow(row: Row): void {
 
 function handleTodosForExistingRow(row: Row): RoleTodoMap {
     const currentRoleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
-    const lastSavedRoleTodoMap: RoleTodoMap  = getRoleTodoIdMap(row);
+    const lastSavedRoleTodoMap: RoleTodoMap  = getRoleTodoMap(row);
 
     deleteObsoleteTodos(currentRoleRequestMap, lastSavedRoleTodoMap);
 
@@ -66,9 +66,9 @@ function handleTodosForExistingRow(row: Row): RoleTodoMap {
     return {...existingRoleTodoMap, ...newRoleTodoMap};
 }
 
-function handleScheduleEntryForExistingRow(row: Row): string {
+function handleScheduleEntryForExistingRow(row: Row, updatedRoleTodoMap: RoleTodoMap): string {
     const scheduleEntryId: string = getSavedScheduleEntryId(row);
-    const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row);
+    const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, updatedRoleTodoMap);
     const scheduleEntryIdentifier: ScheduleEntryIdentifier = getScheduleEntryIdentifier(scheduleEntryId);
     updateScheduleEntry(scheduleEntryRequest, scheduleEntryIdentifier);
 
@@ -86,7 +86,7 @@ function processNewRow(row: Row): void {
     const roleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
     const roleTodoMap: RoleTodoMap = createNewTodos(roleRequestMap);
 
-    const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row);
+    const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, roleTodoMap);
     const scheduleEntryId: string = createScheduleEntry(scheduleEntryRequest, getDefaultScheduleIdentifier());
 
     generateIdForRow(row);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,23 +47,23 @@ export function importOnestopToBasecamp(): void {
 function processExistingRow(row: Row): void {
 
     if(hasChanged(row)) {
-        const updatedRoleTodoIdMap: RoleTodoIdMap = handleTodosForExistingRow(row);
+        const updatedRoleTodoMap: RoleTodoMap = handleTodosForExistingRow(row);
         const scheduleEntryId: string = handleScheduleEntryForExistingRow(row);
 
-        saveRow(row, updatedRoleTodoIdMap, scheduleEntryId);
+        saveRow(row, updatedRoleTodoMap, scheduleEntryId);
     }
 }
 
-function handleTodosForExistingRow(row: Row): RoleTodoIdMap {
+function handleTodosForExistingRow(row: Row): RoleTodoMap {
     const currentRoleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
-    const lastSavedRoleTodoIdMap: RoleTodoIdMap  = getRoleTodoIdMap(row);
+    const lastSavedRoleTodoMap: RoleTodoMap  = getRoleTodoIdMap(row);
 
-    deleteObsoleteTodos(currentRoleRequestMap, lastSavedRoleTodoIdMap);
+    deleteObsoleteTodos(currentRoleRequestMap, lastSavedRoleTodoMap);
 
-    const newRoleTodoIdMap: RoleTodoIdMap = createTodosForNewRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
-    const existingRoleTodoIdMap: RoleTodoIdMap = updateTodosForExistingRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
+    const newRoleTodoMap: RoleTodoMap = createTodosForNewRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
+    const existingRoleTodoMap: RoleTodoMap = updateTodosForExistingRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
 
-    return {...existingRoleTodoIdMap, ...newRoleTodoIdMap};
+    return {...existingRoleTodoMap, ...newRoleTodoMap};
 }
 
 function handleScheduleEntryForExistingRow(row: Row): string {
@@ -84,13 +84,13 @@ function handleScheduleEntryForExistingRow(row: Row): string {
  */
 function processNewRow(row: Row): void {
     const roleRequestMap: RoleRequestMap = getBasecampTodoRequestsForRow(row);
-    const roleTodoIdMap: RoleTodoIdMap = createNewTodos(roleRequestMap);
+    const roleTodoMap: RoleTodoMap = createNewTodos(roleRequestMap);
 
     const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row);
     const scheduleEntryId: string = createScheduleEntry(scheduleEntryRequest, getDefaultScheduleIdentifier());
 
     generateIdForRow(row);
-    saveRow(row, roleTodoIdMap, scheduleEntryId);
+    saveRow(row, roleTodoMap, scheduleEntryId);
 }
 
 function deleteOldRows(processedRowIds: string[]): void {
@@ -102,8 +102,8 @@ function deleteOldRows(processedRowIds: string[]): void {
             const rowBasecampMapping: RowBasecampMapping = propertyStore[rowId];
 
             // Handle Todos
-            const roleTodoIdMap: RoleTodoIdMap = rowBasecampMapping.roleTodoIdMap;
-            const todoIds: string[] = Object.values(roleTodoIdMap);
+            const roleTodoMap: RoleTodoMap = rowBasecampMapping.roleTodoMap;
+            const todoIds: string[] = Object.values(roleTodoMap).map(todo => todo.id);
             deleteTodos(todoIds);
 
             // Handle Schedule Entries

--- a/src/main/role.ts
+++ b/src/main/role.ts
@@ -1,10 +1,10 @@
 /**
- * Gets a list of roles from a roleTodoIdMap
+ * Gets a list of roles from a roleTodoMap
  * 
- * @param roleTodoIdMap a map associating an event's roles with todo ids
+ * @param roleTodoMap a map associating an event's roles with todo objects
  */
-function getOriginalEventRoles(roleTodoIdMap: RoleTodoIdMap): string[] {
-    return Object.keys(roleTodoIdMap);
+function getOriginalEventRoles(roleTodoMap: RoleTodoMap): string[] {
+    return Object.keys(roleTodoMap);
 }
 
 /**
@@ -20,12 +20,12 @@ function getCurrentEventRoles(currentRoleRequestMap: RoleRequestMap): string[] {
  * Gets a list of obsolete roles by comparing the original and current roles
  * 
  * @param currentRoleRequestMap a map associating an event's roles with API request bodies
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects, that is currently saved in the document properties
  * @returns an array of removed roles
  */
-export function getRemovedRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+export function getRemovedRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): string[] {
     const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
-    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoMap);
     return originalRoles.filter(role => !currentRoles.includes(role));
 }
 
@@ -33,12 +33,12 @@ export function getRemovedRoles(currentRoleRequestMap: RoleRequestMap, lastSaved
  * Gets a list of existing roles by comparing the original and current roles
  * 
  * @param currentRoleRequestMap a map associating an event's roles with API request bodies
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects, that is currently saved in the document properties
  * @returns an array of existing roles
  */
-export function getExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+export function getExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): string[] {
     const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
-    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoMap);
     return currentRoles.filter(role => originalRoles.includes(role));
 }
 
@@ -46,11 +46,11 @@ export function getExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSave
  * Gets a list of new roles by comparing the original and current roles
  * 
  * @param currentRoleRequestMap a map associating an event's roles with API request bodies
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo IDs, that is currently saved in the document properties
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects, that is currently saved in the document properties
  * @returns an array of new roles
  */
-export function getNewRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+export function getNewRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): string[] {
     const currentRoles: string[] = getCurrentEventRoles(currentRoleRequestMap);
-    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoIdMap);
+    const originalRoles: string[] = getOriginalEventRoles(lastSavedRoleTodoMap);
     return currentRoles.filter(role => !originalRoles.includes(role));
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -748,8 +748,8 @@ function getScheduleEntryDescription(row: Row, roleTodoMap: RoleTodoMap): string
 
 function getRichTextForTodoLinks(roleTodoMap: RoleTodoMap): string {
     let richText: string = "RELATED TODOS: <ul>";
-    for(const [role, todo] of Object.entries(roleTodoMap)) {
-        richText += `<li>${role}: ${todo.url}</li>`;
+    for(const todo of Object.values(roleTodoMap)) {
+        richText += `<li><a href="${todo.url}">${todo.title}</a></li>`;
     }
     richText += "</ul>";
 

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -89,10 +89,10 @@ export function hasId(row: Row): boolean {
  * Saves a given row's contents to the PropertiesService
  * 
  * @param row the row's contents to write
- * @param roleTodoIdMap a map that has role titles as the keys and todo ids as the values
+ * @param roleTodoMap a map that has role titles as the keys and todo objects as the values
  * @param scheduleEntryId id of the schedule entry created for this row
  */
-export function saveRow(row: Row, roleTodoIdMap: RoleTodoIdMap, scheduleEntryId: string): void {
+export function saveRow(row: Row, roleTodoMap: RoleTodoMap, scheduleEntryId: string): void {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }
@@ -100,7 +100,7 @@ export function saveRow(row: Row, roleTodoIdMap: RoleTodoIdMap, scheduleEntryId:
     const rowId: string = getId(row);
     const rowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, toString(row)));
     const tabInfo: TabInfo = { date: row.date };
-    const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash, roleTodoIdMap: roleTodoIdMap, scheduleEntryId: scheduleEntryId, tabInfo: tabInfo};
+    const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash, roleTodoMap: roleTodoMap, scheduleEntryId: scheduleEntryId, tabInfo: tabInfo};
 
     setDocumentProperty(rowId, JSON.stringify(rowBasecampMapping));
 }
@@ -685,14 +685,14 @@ function filterDomainAttendees(domainNames: string[], domainFilters: string[]): 
  * Used for downstream processing
  * 
  * @param row a list of all the current roles associated with the row including the lead role. This may be identical to the original roles
- * @returns a map that associates role titles with basecamp todo ids
+ * @returns a map that associates role titles with basecamp todo objects
  */
-export function getRoleTodoIdMap(row: Row): RoleTodoIdMap {
+export function getRoleTodoIdMap(row: Row): RoleTodoMap {
     const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
     if(savedRowBasecampMapping === null) {
         throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null! Unable to proceed with updating the todo!");
     }
-    return savedRowBasecampMapping.roleTodoIdMap;
+    return savedRowBasecampMapping.roleTodoMap;
 }
 
 export function getSavedScheduleEntryId(row: Row): string {

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -93,15 +93,15 @@ export function getBasecampTodoRequest(content: string, description: string, ass
  * @returns a map that associates role titles with basecamp todo ids
  */
 export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoMap {
-    const roleTodoIdMap: RoleTodoMap = {};
+    const roleTodoMap: RoleTodoMap = {};
 
     Object.keys(roleRequestMap).forEach( role => {
         let request: BasecampTodoRequest = roleRequestMap[role];
         let basecampTodo: BasecampTodo = createTodo(request, getDefaultTodoListIdentifier());
-        roleTodoIdMap[role] = basecampTodo;
+        roleTodoMap[role] = basecampTodo;
     });
 
-    return roleTodoIdMap;
+    return roleTodoMap;
 }
 
 /**
@@ -149,7 +149,7 @@ export function deleteObsoleteTodos(currentRoleRequestMap: RoleRequestMap, lastS
  * Gets a list of obsolete todo ids based off of the obsolete roels roles by comparing the original and current roles together
  * 
  * @param obsoleteRoles an array of obsolete roles
- * @param lastSavedRoleTodoIdMap a map associating an event's roles with todo ids
+ * @param lastSavedRoleTodoMap a map associating an event's roles with todo objects
  * @returns an array of obsolete roles
  */
 export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoMap: RoleTodoMap): string[] {
@@ -167,7 +167,7 @@ export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoMa
 
 /**
  * Updates todos for existing roles. Gets the request body from the roleRequestMap map
- * Gets the existing todo id from the roleTodoIdMap object
+ * Gets the existing todo id from the roleTodoMap object
  * 
  * @param currentRoleRequestMap a map associating role titles with BasecampTodoRequest objects
  * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects that is currently saved in the document properties
@@ -175,7 +175,7 @@ export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoMa
  */
 export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): RoleTodoMap {
     Logger.log("Updating todos for existing roles...");
-    const existingRoleTodoIdMap: RoleTodoMap = {};
+    const existingRoleTodoMap: RoleTodoMap = {};
     const existingRoles: string[] = getExistingRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
 
     for(const role of existingRoles) {
@@ -196,10 +196,10 @@ export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMa
 
         updateTodo(request, todoIdentifier);
 
-        existingRoleTodoIdMap[role] = existingTodo;
+        existingRoleTodoMap[role] = existingTodo;
     }
 
-    return existingRoleTodoIdMap;
+    return existingRoleTodoMap;
 }
 
 /**
@@ -213,7 +213,7 @@ export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, la
     Logger.log("Checking for new roles...\n");
 
     const newRoles: string[] = getNewRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
-    const newRoleTodoIdMap: RoleTodoMap = {};
+    const newRoleTodoMap: RoleTodoMap = {};
     
     if(newRoles.length > 0) {
         Logger.log(`New role(s) detected: ${newRoles}\n`);
@@ -225,14 +225,14 @@ export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, la
             }
 
             let newTodoId = createTodo(request, getDefaultTodoListIdentifier());
-            newRoleTodoIdMap[role] = newTodoId;
+            newRoleTodoMap[role] = newTodoId;
         }
 
     } else {
         Logger.log("No new roles detected!\n");
     }
 
-    return newRoleTodoIdMap;
+    return newRoleTodoMap;
 }
 
 function getDefaultTodoListIdentifier(): TodolistIdentifier {

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -18,13 +18,13 @@ export const TODOLIST_ID: string= "7865336721";
  * 
  * @param request object to put in Basecamp
  * @param todolistIdentifier id of the todolist where the todo will be created in
- * @returns the id of the created todo. This must be saved by the caller to update this todo in the future.
+ * @returns a BasecampTodo object representing the created Todo
  */
-export function createTodo(request: BasecampTodoRequest, todolistIdentifier: TodolistIdentifier): string {
+export function createTodo(request: BasecampTodoRequest, todolistIdentifier: TodolistIdentifier): BasecampTodo {
     Logger.log(`Creating new todo: "${request.content}"...\n`);
     const rawTodoResponse: JsonData = sendBasecampPostRequest(getCreateTodoUrl(todolistIdentifier), request);
     const todoResponse: BasecampTodoResponse = rawTodoResponse as BasecampTodoResponse;
-    return todoResponse.id;
+    return { id: todoResponse.id, url: todoResponse.app_url };
 }
 
 /**
@@ -92,13 +92,13 @@ export function getBasecampTodoRequest(content: string, description: string, ass
  * @param basecampRequests array of BasecampTodoRequest objects to send
  * @returns a map that associates role titles with basecamp todo ids
  */
-export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoIdMap {
-    const roleTodoIdMap: RoleTodoIdMap = {};
+export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoMap {
+    const roleTodoIdMap: RoleTodoMap = {};
 
     Object.keys(roleRequestMap).forEach( role => {
         let request: BasecampTodoRequest = roleRequestMap[role];
-        let basecampTodoId: string = createTodo(request, getDefaultTodoListIdentifier());
-        roleTodoIdMap[role] = basecampTodoId;
+        let basecampTodo: BasecampTodo = createTodo(request, getDefaultTodoListIdentifier());
+        roleTodoIdMap[role] = basecampTodo;
     });
 
     return roleTodoIdMap;
@@ -127,15 +127,15 @@ export function deleteTodos(todoIds: string[]): void {
  * The first line checks whether there are any rows present in the original roles that are not present in the current roles (indicating an obsolete role)
  * 
  * @param currentRoleRequestMap a map associating an event's roles with api request bodies
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo ids, that is currently saved in the document properties
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects, that is currently saved in the document properties
  * @returns a string array of obsolete roles that were deleted
  */
-export function deleteObsoleteTodos(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+export function deleteObsoleteTodos(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): string[] {
     Logger.log("Checking for removed roles...\n")
-    const removedRoles: string[] = getRemovedRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
+    const removedRoles: string[] = getRemovedRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
 
     if(removedRoles.length > 0) {
-        const obsoleteTodoIds: string[] = getObsoleteTodosIds(removedRoles, lastSavedRoleTodoIdMap);
+        const obsoleteTodoIds: string[] = getObsoleteTodosIds(removedRoles, lastSavedRoleTodoMap);
         deleteTodos(obsoleteTodoIds);
 
     } else {
@@ -152,13 +152,13 @@ export function deleteObsoleteTodos(currentRoleRequestMap: RoleRequestMap, lastS
  * @param lastSavedRoleTodoIdMap a map associating an event's roles with todo ids
  * @returns an array of obsolete roles
  */
-export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoIdMap: RoleTodoIdMap): string[] {
+export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoMap: RoleTodoMap): string[] {
 
     const obsoleteTodoIds: string[] = [];
     
     for(const role of obsoleteRoles) {
         Logger.log(`Found removed role: ${role}!\n`);
-        let todoId: string = lastSavedRoleTodoIdMap[role];
+        let todoId: string = lastSavedRoleTodoMap[role].id;
         obsoleteTodoIds.push(todoId);
     }
 
@@ -170,33 +170,33 @@ export function getObsoleteTodosIds(obsoleteRoles: string[], lastSavedRoleTodoId
  * Gets the existing todo id from the roleTodoIdMap object
  * 
  * @param currentRoleRequestMap a map associating role titles with BasecampTodoRequest objects
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo ids that is currently saved in the document properties
- * @returns an object mapping surviving roles with their existing todo ids
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects that is currently saved in the document properties
+ * @returns an object mapping surviving roles with their existing todo objects
  */
-export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
+export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): RoleTodoMap {
     Logger.log("Updating todos for existing roles...");
-    const existingRoleTodoIdMap: RoleTodoIdMap = {};
-    const existingRoles: string[] = getExistingRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
+    const existingRoleTodoIdMap: RoleTodoMap = {};
+    const existingRoles: string[] = getExistingRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
 
     for(const role of existingRoles) {
-        let existingTodoId: string = lastSavedRoleTodoIdMap[role];
+        let existingTodo: BasecampTodo = lastSavedRoleTodoMap[role];
         let request: BasecampTodoRequest = currentRoleRequestMap[role];
 
         if(request === undefined) {
             throw new BasecampRequestMissingError("Missing basecamp request!");
 
-        } else if(existingTodoId === undefined) {
+        } else if(existingTodo.id === undefined) {
             throw new TodoIdMissingError("Missing todo id!");
         }
         
         let todoIdentifier: TodoIdentifier = {
             projectId: BASECAMP_PROJECT_ID,
-            todoId: existingTodoId
+            todoId: existingTodo.id
         };
 
         updateTodo(request, todoIdentifier);
 
-        existingRoleTodoIdMap[role] = existingTodoId;
+        existingRoleTodoIdMap[role] = existingTodo;
     }
 
     return existingRoleTodoIdMap;
@@ -206,14 +206,14 @@ export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMa
  * Create todos for new roles. Gets the request body from the roleRequestMap map
  * 
  * @param currentRoleRequestMap a map associating an event's roles with api request bodies
- * @param lastSavedRoleTodoIdMap a map associating an event's roles to existing todo ids that is currently saved in the document properties
- * @returns an object mapping new roles with their newly created todo ids
+ * @param lastSavedRoleTodoMap a map associating an event's roles to existing todo objects that is currently saved in the document properties
+ * @returns an object mapping new roles with their newly created todo objects
  */
-export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoIdMap: RoleTodoIdMap): RoleTodoIdMap {
+export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, lastSavedRoleTodoMap: RoleTodoMap): RoleTodoMap {
     Logger.log("Checking for new roles...\n");
 
-    const newRoles: string[] = getNewRoles(currentRoleRequestMap, lastSavedRoleTodoIdMap);
-    const newRoleTodoIdMap: RoleTodoIdMap = {};
+    const newRoles: string[] = getNewRoles(currentRoleRequestMap, lastSavedRoleTodoMap);
+    const newRoleTodoIdMap: RoleTodoMap = {};
     
     if(newRoles.length > 0) {
         Logger.log(`New role(s) detected: ${newRoles}\n`);

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -24,7 +24,7 @@ export function createTodo(request: BasecampTodoRequest, todolistIdentifier: Tod
     Logger.log(`Creating new todo: "${request.content}"...\n`);
     const rawTodoResponse: JsonData = sendBasecampPostRequest(getCreateTodoUrl(todolistIdentifier), request);
     const todoResponse: BasecampTodoResponse = rawTodoResponse as BasecampTodoResponse;
-    return { id: todoResponse.id, url: todoResponse.app_url };
+    return { id: todoResponse.id, title: todoResponse.title, url: todoResponse.app_url };
 }
 
 /**

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -41,7 +41,7 @@ declare interface BasecampTodo {
   url: string,
 }
 
-// The key string represents a role and the value represents a todoId
+// The key string represents a role and the value represents a todo object
 type RoleTodoMap = { [role: string]: BasecampTodo };
 
 declare interface TabInfo {

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -36,8 +36,13 @@ declare interface Row {
   notes: Text
 }
 
+declare interface BasecampTodo {
+  id: string,
+  url: string,
+}
+
 // The key string represents a role and the value represents a todoId
-type RoleTodoIdMap = { [role: string]: string };
+type RoleTodoMap = { [role: string]: BasecampTodo };
 
 declare interface TabInfo {
   date: Date
@@ -45,7 +50,7 @@ declare interface TabInfo {
 
 declare interface RowBasecampMapping {
   rowHash: string,
-  roleTodoIdMap: RoleTodoIdMap
+  roleTodoMap: RoleTodoMap
   scheduleEntryId: string,
   tabInfo: TabInfo
 }
@@ -97,7 +102,8 @@ declare interface BasecampTodoRequest extends JsonObject {
 
 // Response from Basecamp Todo. Only need id for now, can add more later
 declare interface BasecampTodoResponse extends JsonObject {
-  id: string // id of the created todo
+  id: string, // id of the created todo
+  app_url: string // url of the created todo
 }
 
 declare interface ScheduleIdentifier {

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -38,6 +38,7 @@ declare interface Row {
 
 declare interface BasecampTodo {
   id: string,
+  title: string,
   url: string,
 }
 
@@ -103,6 +104,7 @@ declare interface BasecampTodoRequest extends JsonObject {
 // Response from Basecamp Todo. Only need id for now, can add more later
 declare interface BasecampTodoResponse extends JsonObject {
   id: string, // id of the created todo
+  title: string, // title of the created todo
   app_url: string // url of the created todo
 }
 


### PR DESCRIPTION
* Renames `RoleTodoIdMap` to `RoleTodoMap` as we are no longer just mapping to just the Basecamp Todo id
* Adds corresponding Todo links to the Schedule Entry event description

![Screenshot 2025-01-27 at 2 50 13 PM](https://github.com/user-attachments/assets/1ea95f3e-a687-4e23-9530-ff91bba09c06)
