### PR TITLE
HTTP exception resiliency

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -2,20 +2,20 @@ import { Logger } from 'gasmask';
 global.Logger = Logger;
 
 import randomstring from "randomstring";
-import { getRandomlyGeneratedRoleRequestMap, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedScheduleEntry, getRandomlyGeneratedScheduleEntryIdentifier, getRandomlyGeneratedScheduleIdentifier, Mock } from "./testUtils";
+import { getRandomlyGeneratedRoleRequestMap, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedScheduleEntryRequest, getRandomlyGeneratedScheduleEntryIdentifier, getRandomlyGeneratedScheduleIdentifier, Mock } from "./testUtils";
 
 describe("importOnestopToBasecamp", () => {
     it("should create new Todos and Schedule Entries when a row is new", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock1: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
         const roleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
-        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const rowIdMock1: string = randomstring.generate();
         const rowMock2: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
         const roleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
-        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
+        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleEntryIdMock2: string = randomstring.generate();
         const rowIdMock2: string = randomstring.generate();
         const documentPropertiesMock: DocumentProperties = {
@@ -178,7 +178,7 @@ describe("importOnestopToBasecamp", () => {
     it("should update existing Todos and Schedule Entries when a row is not new", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock1: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
-        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const scheduleEntryIdentifierMock1: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
         const rowIdMock1: string = randomstring.generate();
@@ -188,7 +188,7 @@ describe("importOnestopToBasecamp", () => {
         const existingRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
         const updatedRoleTodoMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
         const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
-        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
+        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleEntryIdMock2: string = randomstring.generate();
         const scheduleEntryIdentifierMock2: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
         const rowIdMock2: string = randomstring.generate();
@@ -462,7 +462,7 @@ describe("importOnestopToBasecamp", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const roleRequestMapMock1: RoleRequestMap = {};
         const roleTodoMapMock1: RoleTodoMap = {};
-        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntry();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const rowIdMock1: string = randomstring.generate();
         const documentPropertiesMock: DocumentProperties = {

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -465,8 +465,8 @@ describe("importOnestopToBasecamp", () => {
             .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
             .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
         const getSavedScheduleEntryIdMock: Mock = jest.fn()
-            .mockReturnValueOnce("")
-            .mockReturnValueOnce("");
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(undefined);
 
         jest.mock("../src/main/row", () => ({
             hasId: hasIdMock,
@@ -574,8 +574,8 @@ describe("importOnestopToBasecamp", () => {
             .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
             .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
         const getSavedScheduleEntryIdMock: Mock = jest.fn()
-            .mockReturnValueOnce("")
-            .mockReturnValueOnce("");
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(undefined);
 
         jest.mock("../src/main/row", () => ({
             hasId: hasIdMock,

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -22,7 +22,6 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
-        const scheduleIdentifierMock: ScheduleIdentifier = getRandomlyGeneratedScheduleIdentifier();
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
@@ -64,14 +63,12 @@ describe("importOnestopToBasecamp", () => {
             createNewTodos: createNewTodosMock,
         }));
 
-        const createScheduleEntryMock: Mock = jest.fn()
+        const createScheduleEntryForRowMock: Mock = jest.fn()
             .mockReturnValueOnce(scheduleEntryIdMock1)
             .mockReturnValueOnce(scheduleEntryIdMock2);
-        const getDefaultScheduleIdentifierMock: Mock = jest.fn(() => scheduleIdentifierMock);
 
         jest.mock("../src/main/schedule", () => ({
-            createScheduleEntry: createScheduleEntryMock,
-            getDefaultScheduleIdentifier: getDefaultScheduleIdentifierMock,
+            createScheduleEntryForRow: createScheduleEntryForRowMock,
         }));
 
         const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
@@ -87,18 +84,18 @@ describe("importOnestopToBasecamp", () => {
 
         // Asserts for new first row
         expect(createNewTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1);
-        expect(createScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleIdentifierMock);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(1, rowMock1);
         expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1, scheduleEntryIdMock1);
     
         // Asserts for new second row
         expect(createNewTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2);
-        expect(createScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryRequestMock2, scheduleIdentifierMock);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(2, rowMock2, roleTodoMapMock2);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(2, rowMock2);
         expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, roleTodoMapMock2, scheduleEntryIdMock2);
     });
 
-    it("should skip existing rows when the row has not changed", () => {
+    it("should skip existing rows when the row has not changed and there are no missing Todos or Schedule Entries", () => {
         const rowMock1: Row = getRandomlyGeneratedRow();
         const scheduleEntryIdMock1: string = randomstring.generate();
         const rowIdMock1: string = randomstring.generate();
@@ -125,11 +122,15 @@ describe("importOnestopToBasecamp", () => {
         const getIdMock: Mock = jest.fn()
             .mockReturnValueOnce(rowIdMock1)
             .mockReturnValueOnce(rowIdMock2);
+        const isMissingTodosMock: Mock = jest.fn(() => false);
+        const isMissingScheduleEntryMock: Mock = jest.fn(() => false);
 
         jest.mock("../src/main/row", () => ({
             hasId: hasIdMock,
             hasChanged: hasChangedMock,
             getId: getIdMock,
+            isMissingTodos: isMissingTodosMock,
+            isMissingScheduleEntry: isMissingScheduleEntryMock,
         }));
 
         const deleteObsoleteTodosMock: Mock = jest.fn();
@@ -142,9 +143,6 @@ describe("importOnestopToBasecamp", () => {
             updateTodosForExistingRoles: updateTodosForExistingRolesMock,
         }));
 
-        const createScheduleEntryMock: Mock = jest.fn()
-            .mockReturnValueOnce(scheduleEntryIdMock1)
-            .mockReturnValueOnce(scheduleEntryIdMock2);
         const updateScheduleEntryMock: Mock = jest.fn();
 
         jest.mock("../src/main/schedule", () => ({
@@ -164,9 +162,11 @@ describe("importOnestopToBasecamp", () => {
 
         // Asserts for non-changed first row
         expect(hasChangedMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(isMissingScheduleEntryMock).toHaveBeenNthCalledWith(1, rowMock1);
     
         // Asserts for non-changed second row
         expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(isMissingScheduleEntryMock).toHaveBeenNthCalledWith(2, rowMock2);
 
         // Asserts for existing row
         expect(deleteObsoleteTodosMock).toHaveBeenCalledTimes(0);
@@ -219,7 +219,6 @@ describe("importOnestopToBasecamp", () => {
         const getScheduleEntryRequestForRowMock: Mock = jest.fn()
             .mockReturnValueOnce(scheduleEntryRequestMock1)
             .mockReturnValueOnce(scheduleEntryRequestMock2);
-        const generateIdForRowMock: Mock = jest.fn();
         const saveRowMock: Mock = jest.fn();
         const getIdMock: Mock = jest.fn()
             .mockReturnValueOnce(rowIdMock1)
@@ -256,9 +255,6 @@ describe("importOnestopToBasecamp", () => {
             updateTodosForExistingRoles: updateTodosForExistingRolesMock,
         }));
 
-        const createScheduleEntryMock: Mock = jest.fn()
-            .mockReturnValueOnce(scheduleEntryIdMock1)
-            .mockReturnValueOnce(scheduleEntryIdMock2);
         const getScheduleEntryIdentifierMock: Mock = jest.fn()
             .mockReturnValueOnce(scheduleEntryIdentifierMock1)
             .mockReturnValueOnce(scheduleEntryIdentifierMock2);
@@ -270,7 +266,6 @@ describe("importOnestopToBasecamp", () => {
         }));
 
         const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
-        const deleteDocumentPropertyMock: Mock = jest.fn();
 
         jest.mock("../src/main/propertiesService", () => ({
             getAllDocumentProperties: getAllDocumentPropertiesMock,
@@ -296,6 +291,334 @@ describe("importOnestopToBasecamp", () => {
         expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
         expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryRequestMock2, scheduleEntryIdentifierMock2);
         expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoMapMock2, scheduleEntryIdMock2);
+    });
+
+    it("should update existing Todos and Schedule Entries when a row has not changed but is missing Todos", () => {
+        const rowMock1: Row = getRandomlyGeneratedRow();
+        const roleRequestMapMock1: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock1: string = randomstring.generate();
+        const scheduleEntryIdentifierMock1: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
+        const rowIdMock1: string = randomstring.generate();
+        const rowMock2: Row = getRandomlyGeneratedRow();
+        const lastSavedRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
+        const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock2: string = randomstring.generate();
+        const scheduleEntryIdentifierMock2: ScheduleEntryIdentifier = getRandomlyGeneratedScheduleEntryIdentifier();
+        const rowIdMock2: string = randomstring.generate();
+        const lastSavedRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoMapMock2: RoleTodoMap = {...existingRoleTodoMapMock2, ...newRoleTodoMapMock2};
+        const documentPropertiesMock: DocumentProperties = {
+            [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
+            [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
+        };
+
+        const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
+
+        jest.mock("../src/main/scan", () => ({
+            getEventRowsFromSpreadsheet: getEventRowsFromSpreadsheetMock,
+        }));
+
+        const hasIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true);
+        const hasChangedMock: Mock = jest.fn(() => false);
+        const isMissingTodosMock: Mock = jest.fn(() => true);
+        const getBasecampTodoRequestsForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(roleRequestMapMock1)
+            .mockReturnValueOnce(roleRequestMapMock2);
+        const getScheduleEntryRequestForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryRequestMock1)
+            .mockReturnValueOnce(scheduleEntryRequestMock2);
+        const saveRowMock: Mock = jest.fn();
+        const getIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(rowIdMock1)
+            .mockReturnValueOnce(rowIdMock2);
+        const getRoleTodoMapMock: Mock = jest.fn()
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
+        const getSavedScheduleEntryIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryIdMock1)
+            .mockReturnValueOnce(scheduleEntryIdMock2);
+
+        jest.mock("../src/main/row", () => ({
+            hasId: hasIdMock,
+            hasChanged: hasChangedMock,
+            isMissingTodos: isMissingTodosMock,
+            getBasecampTodoRequestsForRow: getBasecampTodoRequestsForRowMock,
+            getScheduleEntryRequestForRow: getScheduleEntryRequestForRowMock,
+            saveRow: saveRowMock,
+            getId: getIdMock,
+            getRoleTodoMap: getRoleTodoMapMock,
+            getSavedScheduleEntryId: getSavedScheduleEntryIdMock,
+        }));
+
+        const deleteObsoleteTodosMock: Mock = jest.fn();
+        const createTodosForNewRolesMock: Mock = jest.fn()
+            .mockReturnValueOnce(newRoleTodoMapMock1)
+            .mockReturnValueOnce(newRoleTodoMapMock2);
+        const updateTodosForExistingRolesMock: Mock = jest.fn()
+            .mockReturnValueOnce(existingRoleTodoMapMock1)
+            .mockReturnValueOnce(existingRoleTodoMapMock2);
+
+        jest.mock("../src/main/todos", () => ({
+            deleteObsoleteTodos: deleteObsoleteTodosMock,
+            createTodosForNewRoles: createTodosForNewRolesMock,
+            updateTodosForExistingRoles: updateTodosForExistingRolesMock,
+        }));
+
+        const getScheduleEntryIdentifierMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryIdentifierMock1)
+            .mockReturnValueOnce(scheduleEntryIdentifierMock2);
+        const updateScheduleEntryMock: Mock = jest.fn();
+
+        jest.mock("../src/main/schedule", () => ({
+            getScheduleEntryIdentifier: getScheduleEntryIdentifierMock,
+            updateScheduleEntry: updateScheduleEntryMock,
+        }));
+
+        const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
+
+        jest.mock("../src/main/propertiesService", () => ({
+            getAllDocumentProperties: getAllDocumentPropertiesMock,
+        }));
+
+        const { importOnestopToBasecamp } = require("../src/main/main");
+        importOnestopToBasecamp();
+
+        expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
+
+        // Asserts for changed first row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(isMissingTodosMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleEntryIdentifierMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoMapMock1, scheduleEntryIdMock1);
+    
+        // Asserts for changed second row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(isMissingTodosMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(updateScheduleEntryMock).toHaveBeenNthCalledWith(2, scheduleEntryRequestMock2, scheduleEntryIdentifierMock2);
+        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoMapMock2, scheduleEntryIdMock2);
+    });
+
+    it("should update existing Todos and create a new Schedule Entry when a row is not new and the Schedule Entry is missing", () => {
+        const rowMock1: Row = getRandomlyGeneratedRow();
+        const roleRequestMapMock1: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock1: string = randomstring.generate();
+        const rowIdMock1: string = randomstring.generate();
+        const rowMock2: Row = getRandomlyGeneratedRow();
+        const lastSavedRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoMapMock1: RoleTodoMap = {...existingRoleTodoMapMock1, ...newRoleTodoMapMock1};
+        const roleRequestMapMock2: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock2: string = randomstring.generate();
+        const rowIdMock2: string = randomstring.generate();
+        const lastSavedRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const newRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const existingRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const updatedRoleTodoMapMock2: RoleTodoMap = {...existingRoleTodoMapMock2, ...newRoleTodoMapMock2};
+        const documentPropertiesMock: DocumentProperties = {
+            [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
+            [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
+        };
+
+        const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
+
+        jest.mock("../src/main/scan", () => ({
+            getEventRowsFromSpreadsheet: getEventRowsFromSpreadsheetMock,
+        }));
+
+        const hasIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true);
+        const hasChangedMock: Mock = jest.fn(() => true);
+        const getBasecampTodoRequestsForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(roleRequestMapMock1)
+            .mockReturnValueOnce(roleRequestMapMock2);
+        const getScheduleEntryRequestForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryRequestMock1)
+            .mockReturnValueOnce(scheduleEntryRequestMock2);
+        const saveRowMock: Mock = jest.fn();
+        const getIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(rowIdMock1)
+            .mockReturnValueOnce(rowIdMock2);
+        const getRoleTodoMapMock: Mock = jest.fn()
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
+        const getSavedScheduleEntryIdMock: Mock = jest.fn()
+            .mockReturnValueOnce("")
+            .mockReturnValueOnce("");
+
+        jest.mock("../src/main/row", () => ({
+            hasId: hasIdMock,
+            hasChanged: hasChangedMock,
+            getBasecampTodoRequestsForRow: getBasecampTodoRequestsForRowMock,
+            getScheduleEntryRequestForRow: getScheduleEntryRequestForRowMock,
+            saveRow: saveRowMock,
+            getId: getIdMock,
+            getRoleTodoMap: getRoleTodoMapMock,
+            getSavedScheduleEntryId: getSavedScheduleEntryIdMock,
+        }));
+
+        const deleteObsoleteTodosMock: Mock = jest.fn();
+        const createTodosForNewRolesMock: Mock = jest.fn()
+            .mockReturnValueOnce(newRoleTodoMapMock1)
+            .mockReturnValueOnce(newRoleTodoMapMock2);
+        const updateTodosForExistingRolesMock: Mock = jest.fn()
+            .mockReturnValueOnce(existingRoleTodoMapMock1)
+            .mockReturnValueOnce(existingRoleTodoMapMock2);
+
+        jest.mock("../src/main/todos", () => ({
+            deleteObsoleteTodos: deleteObsoleteTodosMock,
+            createTodosForNewRoles: createTodosForNewRolesMock,
+            updateTodosForExistingRoles: updateTodosForExistingRolesMock,
+        }));
+
+        const updateScheduleEntryMock: Mock = jest.fn();
+        const createScheduleEntryForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryIdMock1)
+            .mockReturnValueOnce(scheduleEntryIdMock2);
+
+        jest.mock("../src/main/schedule", () => ({
+            updateScheduleEntry: updateScheduleEntryMock,
+            createScheduleEntryForRow: createScheduleEntryForRowMock,
+        }));
+
+        const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
+
+        jest.mock("../src/main/propertiesService", () => ({
+            getAllDocumentProperties: getAllDocumentPropertiesMock,
+        }));
+
+        const { importOnestopToBasecamp } = require("../src/main/main");
+        importOnestopToBasecamp();
+
+        expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
+
+        // Asserts for changed first row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(1, roleRequestMapMock1, lastSavedRoleTodoMapMock1);
+        expect(updateScheduleEntryMock).toHaveBeenCalledTimes(0);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoMapMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, updatedRoleTodoMapMock1, scheduleEntryIdMock1);
+    
+        // Asserts for changed second row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(deleteObsoleteTodosMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(createTodosForNewRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(updateTodosForExistingRolesMock).toHaveBeenNthCalledWith(2, roleRequestMapMock2, lastSavedRoleTodoMapMock2);
+        expect(updateScheduleEntryMock).toHaveBeenCalledTimes(0);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoMapMock2);
+        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, updatedRoleTodoMapMock2, scheduleEntryIdMock2);
+    });
+
+    it("should create a new Schedule Entry when the row is not new and there are no changes but the Schedule Entry is missing", () => {
+        const rowMock1: Row = getRandomlyGeneratedRow();
+        const scheduleEntryRequestMock1: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock1: string = randomstring.generate();
+        const rowIdMock1: string = randomstring.generate();
+        const rowMock2: Row = getRandomlyGeneratedRow();
+        const lastSavedRoleTodoMapMock1: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const scheduleEntryRequestMock2: BasecampScheduleEntryRequest = getRandomlyGeneratedScheduleEntryRequest();
+        const scheduleEntryIdMock2: string = randomstring.generate();
+        const rowIdMock2: string = randomstring.generate();
+        const lastSavedRoleTodoMapMock2: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const documentPropertiesMock: DocumentProperties = {
+            [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
+            [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
+        };
+
+        const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
+
+        jest.mock("../src/main/scan", () => ({
+            getEventRowsFromSpreadsheet: getEventRowsFromSpreadsheetMock,
+        }));
+
+        const hasIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true);
+        const hasChangedMock: Mock = jest.fn(() => false);
+        const isMissingTodosMock: Mock = jest.fn(() => false);
+        const isMissingScheduleEntryMock: Mock = jest.fn(() => true);
+        const getScheduleEntryRequestForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryRequestMock1)
+            .mockReturnValueOnce(scheduleEntryRequestMock2);
+        const saveRowMock: Mock = jest.fn();
+        const getIdMock: Mock = jest.fn()
+            .mockReturnValueOnce(rowIdMock1)
+            .mockReturnValueOnce(rowIdMock2);
+        const getRoleTodoMapMock: Mock = jest.fn()
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock1)
+            .mockReturnValueOnce(lastSavedRoleTodoMapMock2);
+        const getSavedScheduleEntryIdMock: Mock = jest.fn()
+            .mockReturnValueOnce("")
+            .mockReturnValueOnce("");
+
+        jest.mock("../src/main/row", () => ({
+            hasId: hasIdMock,
+            hasChanged: hasChangedMock,
+            isMissingTodos: isMissingTodosMock,
+            isMissingScheduleEntry: isMissingScheduleEntryMock,
+            getScheduleEntryRequestForRow: getScheduleEntryRequestForRowMock,
+            saveRow: saveRowMock,
+            getId: getIdMock,
+            getRoleTodoMap: getRoleTodoMapMock,
+            getSavedScheduleEntryId: getSavedScheduleEntryIdMock,
+        }));
+
+        const createScheduleEntryForRowMock: Mock = jest.fn()
+            .mockReturnValueOnce(scheduleEntryIdMock1)
+            .mockReturnValueOnce(scheduleEntryIdMock2);
+
+        jest.mock("../src/main/schedule", () => ({
+            createScheduleEntryForRow: createScheduleEntryForRowMock,
+        }));
+
+        const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
+
+        jest.mock("../src/main/propertiesService", () => ({
+            getAllDocumentProperties: getAllDocumentPropertiesMock,
+        }));
+
+        const { importOnestopToBasecamp } = require("../src/main/main");
+        importOnestopToBasecamp();
+
+        expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
+
+        // Asserts for changed first row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(isMissingScheduleEntryMock).toHaveBeenNthCalledWith(1, rowMock1);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(1, rowMock1, lastSavedRoleTodoMapMock1);
+        expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, lastSavedRoleTodoMapMock1, scheduleEntryIdMock1);
+    
+        // Asserts for changed second row
+        expect(hasChangedMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(isMissingScheduleEntryMock).toHaveBeenNthCalledWith(2, rowMock2);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(2, rowMock2, lastSavedRoleTodoMapMock2);
+        expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, lastSavedRoleTodoMapMock2, scheduleEntryIdMock2);
     });
 
     it("should delete old Todos when a row is deleted", () => {
@@ -468,7 +791,6 @@ describe("importOnestopToBasecamp", () => {
         const documentPropertiesMock: DocumentProperties = {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
         };
-        const scheduleIdentifierMock: ScheduleIdentifier = getRandomlyGeneratedScheduleIdentifier();
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1]);
 
@@ -504,13 +826,11 @@ describe("importOnestopToBasecamp", () => {
             createNewTodos: createNewTodosMock,
         }));
 
-        const createScheduleEntryMock: Mock = jest.fn()
+        const createScheduleEntryForRowMock: Mock = jest.fn()
             .mockReturnValueOnce(scheduleEntryIdMock1);
-        const getDefaultScheduleIdentifierMock: Mock = jest.fn(() => scheduleIdentifierMock);
 
         jest.mock("../src/main/schedule", () => ({
-            createScheduleEntry: createScheduleEntryMock,
-            getDefaultScheduleIdentifier: getDefaultScheduleIdentifierMock,
+            createScheduleEntryForRow: createScheduleEntryForRowMock,
         }));
 
         const getAllDocumentPropertiesMock: Mock = jest.fn(() => documentPropertiesMock);
@@ -525,9 +845,8 @@ describe("importOnestopToBasecamp", () => {
         expect(getEventRowsFromSpreadsheetMock).toHaveBeenCalledTimes(1);
 
         // Asserts for new first row
-        expect(createScheduleEntryMock).toHaveBeenNthCalledWith(1, scheduleEntryRequestMock1, scheduleIdentifierMock);
+        expect(createScheduleEntryForRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(1, rowMock1);
         expect(saveRowMock).toHaveBeenNthCalledWith(1, rowMock1, roleTodoMapMock1, scheduleEntryIdMock1);
-    
     });
 });

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -1,0 +1,75 @@
+import { Logger, UrlFetchApp } from "gasmask";
+global.Logger = Logger;
+global.UrlFetchApp = UrlFetchApp;
+import { fetchWithRetry } from "../src/main/retry";
+import randomstring from "randomstring";
+import { Mock } from "./testUtils";
+import { RetryError } from "../src/main/error/retryError";
+
+type URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;
+
+describe("fetchWithRetry", () => {
+    it("should return a response when the fetch is successful", () => {
+        const urlMock: string = randomstring.generate();
+        const optionsMock: URLFetchRequestOptions = { method: "get" };
+        const responseMock: HTTPResponse = { test: "test" } as any;
+
+        const sleepMock: Mock = jest.fn();
+        global.Utilities = { sleep: sleepMock };
+
+        jest.spyOn(UrlFetchApp, "fetch").mockReturnValue(responseMock as any);
+
+        const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock);
+
+        expect(result).toEqual(responseMock);
+    });
+
+    it("should return a response when maxRetries is set to 0", () => {
+        const urlMock: string = randomstring.generate();
+        const optionsMock: URLFetchRequestOptions = { method: "get" };
+        const responseMock: HTTPResponse = { test: "test" } as any;
+
+        const sleepMock: Mock = jest.fn();
+        global.Utilities = { sleep: sleepMock };
+
+        jest.spyOn(UrlFetchApp, "fetch").mockReturnValue(responseMock as any);
+
+        const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock, 0);
+
+        expect(result).toEqual(responseMock);
+    });
+
+    it("should retry the fetch when the HTTP request fails", () => {
+        const urlMock: string = randomstring.generate();
+        const optionsMock: URLFetchRequestOptions = { method: "get" };
+        const responseMock: HTTPResponse = { test: "test" } as any;
+
+        const sleepMock: Mock = jest.fn();
+        global.Utilities = { sleep: sleepMock };
+
+        jest.spyOn(UrlFetchApp, "fetch")
+            .mockImplementationOnce(() => {
+                throw new Error("HTTP request failed")
+            })
+            .mockReturnValue(responseMock as any);
+
+        const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock);
+
+        expect(result).toEqual(responseMock);
+    });
+
+    it("should throw a RetryError when the maximum number of retries is reached", () => {
+        const urlMock: string = randomstring.generate();
+        const optionsMock: URLFetchRequestOptions = { method: "get" };
+        const responseMock: HTTPResponse = { test: "test" } as any;
+
+        const sleepMock: Mock = jest.fn();
+        global.Utilities = { sleep: sleepMock };
+
+        jest.spyOn(UrlFetchApp, "fetch").mockImplementation(() => {
+            throw new Error("HTTP request failed")
+        });
+
+        expect(()=> fetchWithRetry(urlMock, optionsMock)).toThrow(RetryError);
+    });
+});

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -12,7 +12,10 @@ describe("fetchWithRetry", () => {
     it("should return a response when the fetch is successful", () => {
         const urlMock: string = randomstring.generate();
         const optionsMock: URLFetchRequestOptions = { method: "get" };
-        const responseMock: HTTPResponse = { test: "test" } as any;
+        const responseMock: HTTPResponse = { 
+            getResponseCode: () => 200,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
 
         const sleepMock: Mock = jest.fn();
         global.Utilities = { sleep: sleepMock };
@@ -22,12 +25,16 @@ describe("fetchWithRetry", () => {
         const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock);
 
         expect(result).toEqual(responseMock);
+        expect(UrlFetchApp.fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should return a response when maxRetries is set to 0", () => {
         const urlMock: string = randomstring.generate();
         const optionsMock: URLFetchRequestOptions = { method: "get" };
-        const responseMock: HTTPResponse = { test: "test" } as any;
+        const responseMock: HTTPResponse = { 
+            getResponseCode: () => 200,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
 
         const sleepMock: Mock = jest.fn();
         global.Utilities = { sleep: sleepMock };
@@ -37,39 +44,69 @@ describe("fetchWithRetry", () => {
         const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock, 0);
 
         expect(result).toEqual(responseMock);
+        expect(UrlFetchApp.fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should retry the fetch when the HTTP request fails", () => {
         const urlMock: string = randomstring.generate();
         const optionsMock: URLFetchRequestOptions = { method: "get" };
-        const responseMock: HTTPResponse = { test: "test" } as any;
+        const responseMock: HTTPResponse = { 
+            getResponseCode: () => 200,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
+        const badResponseMock: HTTPResponse = {
+            getResponseCode: () => 500,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
 
         const sleepMock: Mock = jest.fn();
         global.Utilities = { sleep: sleepMock };
 
         jest.spyOn(UrlFetchApp, "fetch")
-            .mockImplementationOnce(() => {
-                throw new Error("HTTP request failed")
-            })
+            .mockReturnValueOnce(badResponseMock as any)
             .mockReturnValue(responseMock as any);
 
         const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock);
 
         expect(result).toEqual(responseMock);
+        expect(UrlFetchApp.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry the fetch when the HTTP request fails with a 4xx error", () => {
+        const urlMock: string = randomstring.generate();
+        const optionsMock: URLFetchRequestOptions = { method: "get" };
+        const responseMock: HTTPResponse = {
+            getResponseCode: () => 404,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
+
+        const sleepMock: Mock = jest.fn();
+        global.Utilities = { sleep: sleepMock };
+
+        jest.spyOn(UrlFetchApp, "fetch")
+            .mockReturnValueOnce(responseMock as any);
+
+        const result: HTTPResponse = fetchWithRetry(urlMock, optionsMock);
+
+        expect(result).toEqual(responseMock);
+        expect(UrlFetchApp.fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should throw a RetryError when the maximum number of retries is reached", () => {
         const urlMock: string = randomstring.generate();
         const optionsMock: URLFetchRequestOptions = { method: "get" };
-        const responseMock: HTTPResponse = { test: "test" } as any;
+        const badResponseMock: HTTPResponse = {
+            getResponseCode: () => 500,
+            getContentText: () => "responseText"
+        } as HTTPResponse;
 
         const sleepMock: Mock = jest.fn();
         global.Utilities = { sleep: sleepMock };
 
-        jest.spyOn(UrlFetchApp, "fetch").mockImplementation(() => {
-            throw new Error("HTTP request failed")
-        });
+        jest.spyOn(UrlFetchApp, "fetch")
+            .mockReturnValue(badResponseMock as any);
 
         expect(()=> fetchWithRetry(urlMock, optionsMock)).toThrow(RetryError);
+        expect(UrlFetchApp.fetch).toHaveBeenCalledTimes(3);
     });
 });

--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -963,7 +963,7 @@ describe("isMissingScheduleEntry", () =>{
         const rowMock: Row = getRandomlyGeneratedRow();
         rowMock.metadata = metataMock;
         const rowBasecampMappingMock: RowBasecampMapping = getRandomlyGeneratedRowBasecampMapping();
-        rowBasecampMappingMock.scheduleEntryId = "";
+        rowBasecampMappingMock.scheduleEntryId = undefined;
 
         jest.mock('../src/main/propertiesService', () => ({
             getDocumentProperty: jest.fn(() => JSON.stringify(rowBasecampMappingMock)),

--- a/__test__/schedule.test.ts
+++ b/__test__/schedule.test.ts
@@ -1,14 +1,14 @@
-import { Logger } from 'gasmask';
-import randomstring from "randomstring";
-import { getRandomBoolean, getRandomlyGeneratedScheduleEntry, Mock } from "./testUtils";
-import { getBasecampScheduleEntryRequest } from '../src/main/schedule';
-
+import { Logger, PropertiesService } from 'gasmask';
 global.Logger = Logger;
+global.PropertiesService = PropertiesService;
+import randomstring from "randomstring";
+import { getRandomBoolean, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedScheduleEntryRequest, Mock } from "./testUtils";
+import { getBasecampScheduleEntryRequest } from '../src/main/schedule';
 
 describe("createScheduleEntry", () => {
     it("should send a post request with the right url", () => {
         // Arrange
-        const randomScheduleEntry = getRandomlyGeneratedScheduleEntry();
+        const randomScheduleEntry = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleIdentifier: ScheduleIdentifier = {
             projectId: "TEST_PROJECT_ID",
             scheduleId: "TEST_SCHEDULE_ID"
@@ -37,7 +37,7 @@ describe("createScheduleEntry", () => {
 
     it("should return the created schedule entry id", () => {
         // Arrange
-        const randomScheduleEntry = getRandomlyGeneratedScheduleEntry();
+        const randomScheduleEntry = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleIdentifier: ScheduleIdentifier = {
             projectId: randomstring.generate(),
             scheduleId: randomstring.generate()
@@ -62,7 +62,7 @@ describe("createScheduleEntry", () => {
 describe("updateScheduleEntry", () => {
     it("should send a put request with the right url", () => {
         // Arrange
-        const randomScheduleEntry = getRandomlyGeneratedScheduleEntry();
+        const randomScheduleEntry = getRandomlyGeneratedScheduleEntryRequest();
         const scheduleIdentifier: ScheduleEntryIdentifier = {
             projectId: "TEST_PROJECT_ID",
             scheduleEntryId: "TEST_SCHEDULE_ENTRY_ID"
@@ -184,5 +184,54 @@ describe("getScheduleEntryIdentifier", () => {
         const receivedScheduleEntryIdentifier: ScheduleIdentifier = getScheduleEntryIdentifier(scheduleEntryIdMock);
 
         expect(receivedScheduleEntryIdentifier).toStrictEqual(expectedScheduleEntryIdentifier);
+    });
+});
+
+describe("createScheduleEntryForRow", () => {
+    it("should create a schedule entry for the row when there are no exceptions thrown", () => {
+        const rowMock: Row = getRandomlyGeneratedRow();
+        const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+        const scheduleEntryIdMock: string = randomstring.generate();
+
+        jest.mock("../src/main/row", () => ({
+            getScheduleEntryRequestForRow: jest.fn(() => getRandomlyGeneratedScheduleEntryRequest()),
+        }));
+
+        const sendBasecampPostRequestMock: Mock = jest.fn().mockReturnValue({ id: scheduleEntryIdMock });
+        jest.mock("../src/main/basecamp", () => ({
+            sendBasecampPostRequest: sendBasecampPostRequestMock,
+            getBasecampProjectUrl: jest.fn(() => randomstring.generate()),
+        }));
+
+        const { createScheduleEntryForRow } = require("../src/main/schedule");
+
+        const receivedScheduleEntryId: string = createScheduleEntryForRow(rowMock, roleTodoMapMock);
+
+        expect(sendBasecampPostRequestMock).toHaveBeenCalled();
+        expect(receivedScheduleEntryId).toBe(scheduleEntryIdMock);
+    });
+
+    it("should return an empty string when there is an error creating the schedule entry", () => {
+        const rowMock: Row = getRandomlyGeneratedRow();
+        const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
+
+        jest.mock("../src/main/row", () => ({
+            getScheduleEntryRequestForRow: jest.fn(() => getRandomlyGeneratedScheduleEntryRequest()),
+        }));
+
+        const sendBasecampPostRequestMock: Mock = jest.fn().mockImplementation(() => {
+            throw new Error("Test error");
+        });
+        jest.mock("../src/main/basecamp", () => ({
+            sendBasecampPostRequest: sendBasecampPostRequestMock,
+            getBasecampProjectUrl: jest.fn(() => randomstring.generate()),
+        }));
+
+        const { createScheduleEntryForRow } = require("../src/main/schedule");
+
+        const receivedScheduleEntryId: string = createScheduleEntryForRow(rowMock, roleTodoMapMock);
+
+        expect(sendBasecampPostRequestMock).toHaveBeenCalled();
+        expect(receivedScheduleEntryId).toBe("");
     });
 });

--- a/__test__/schedule.test.ts
+++ b/__test__/schedule.test.ts
@@ -211,7 +211,7 @@ describe("createScheduleEntryForRow", () => {
         expect(receivedScheduleEntryId).toBe(scheduleEntryIdMock);
     });
 
-    it("should return an empty string when there is an error creating the schedule entry", () => {
+    it("should return undefined when there is an error creating the schedule entry", () => {
         const rowMock: Row = getRandomlyGeneratedRow();
         const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
 
@@ -232,6 +232,6 @@ describe("createScheduleEntryForRow", () => {
         const receivedScheduleEntryId: string = createScheduleEntryForRow(rowMock, roleTodoMapMock);
 
         expect(sendBasecampPostRequestMock).toHaveBeenCalled();
-        expect(receivedScheduleEntryId).toBe("");
+        expect(receivedScheduleEntryId).toBe(undefined);
     });
 });

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -341,7 +341,7 @@ export function getRandomBoolean(): boolean {
     return getRandomNumber(BOOLEAN_UPPERBOUND) ? true: false;
 }
 
-export function getRandomlyGeneratedScheduleEntry(): BasecampScheduleEntryRequest {
+export function getRandomlyGeneratedScheduleEntryRequest(): BasecampScheduleEntryRequest {
     return {
         summary: randomstring.generate(),
         starts_at: randomstring.generate(),

--- a/__test__/todos.test.ts
+++ b/__test__/todos.test.ts
@@ -1,0 +1,76 @@
+import { Logger } from "gasmask";
+global.Logger = Logger;
+import { getRandomlyGeneratedRoleRequestMap, Mock } from "./testUtils";
+import randomstring from "randomstring";
+
+describe("createTodo", () => {
+
+});
+
+describe("updateTodo", () => {
+
+});
+
+describe("deleteTodo", () => {
+
+});
+
+describe("getBasecampTodoRequest", () => {
+
+});
+
+describe("createNewTodos", () => {
+    it("should create new todos for each role when there are no errors when making requests to basecamp", () => {
+        const roleRequestMapMock: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+
+        const sendBasecampPostRequestMock: Mock = jest.fn().mockReturnValue({ id: randomstring.generate() });
+        jest.mock("../src/main/basecamp", () => ({
+            sendBasecampPostRequest: sendBasecampPostRequestMock,
+            getBasecampProjectUrl: jest.fn(() => randomstring.generate()),
+        }));
+
+        const { createNewTodos } = require("../src/main/todos");
+
+        const receivedRoleTodoMap: RoleTodoMap = createNewTodos(roleRequestMapMock);
+
+        expect(Object.keys(receivedRoleTodoMap)).toHaveLength(Object.keys(roleRequestMapMock).length);
+    });
+
+    it("should return an empty map when all requests to basecamp fail", () => {
+        const roleRequestMapMock: RoleRequestMap = getRandomlyGeneratedRoleRequestMap();
+
+        const sendBasecampPostRequestMock: Mock = jest.fn().mockImplementation(() => {
+            throw new Error("Error");
+        });
+        jest.mock("../src/main/basecamp", () => ({
+            sendBasecampPostRequest: sendBasecampPostRequestMock,
+            getBasecampProjectUrl: jest.fn(() => randomstring.generate()),
+        }));
+
+        const { createNewTodos } = require("../src/main/todos");
+
+        const receivedRoleTodoMap: RoleTodoMap = createNewTodos(roleRequestMapMock);
+
+        expect(Object.keys(receivedRoleTodoMap)).toHaveLength(0);
+    });
+});
+
+describe("deleteTodos", () => {
+
+});
+
+describe("deleteObsoleteTodos", () => {
+
+});
+
+describe("getObsoleteTodosIds", () => {
+
+});
+
+describe("updateTodosForExistingRoles", () => {
+
+});
+
+describe("createTodosForNewRoles", () => {
+
+});

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -1,4 +1,5 @@
 import { BASECAMP_CLIENT_ID, BASECAMP_CLIENT_SECRET } from "../../config/environmentVariables";
+import { fetchWithRetry } from "./retry";
 
 type HttpMethod = GoogleAppsScript.URL_Fetch.HttpMethod;
 
@@ -48,7 +49,7 @@ export function getBasecampUrl(): string {
 }
 
 export function sendBasecampPostRequest(requestUrl: string, requestPayload: JsonObject): JsonData {
-    const response: HTTPResponse = UrlFetchApp.fetch(requestUrl, {
+    const response: HTTPResponse = fetchWithRetry(requestUrl, {
         method: HTTP_POST_METHOD,
         headers: getHeaders(),
         payload: JSON.stringify(requestPayload)
@@ -57,7 +58,7 @@ export function sendBasecampPostRequest(requestUrl: string, requestPayload: Json
 }
 
 export function sendBasecampPutRequest(requestUrl: string, requestPayload: JsonObject): JsonData {
-    const response: HTTPResponse = UrlFetchApp.fetch(requestUrl, {
+    const response: HTTPResponse = fetchWithRetry(requestUrl, {
         method: HTTP_PUT_METHOD,
         headers: getHeaders(),
         payload: JSON.stringify(requestPayload)
@@ -172,7 +173,7 @@ function getHeaders(): Record<string, string> {
 }
 
 function sendBasecampGetRequest(requestUrl: string): HTTPResponse {
-    return UrlFetchApp.fetch(requestUrl, {
+    return fetchWithRetry(requestUrl, {
         method: HTTP_GET_METHOD,
         headers: getHeaders()
     });

--- a/src/main/error/retryError.ts
+++ b/src/main/error/retryError.ts
@@ -1,0 +1,9 @@
+export class RetryError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "RetryError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, RetryError.prototype);
+    }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,10 +47,12 @@ export function importOnestopToBasecamp(): void {
 function processExistingRow(row: Row): void {
 
     if(hasChanged(row) || isMissingTodos(row)) {
+        // Update Todos and Schedule Entry if the row has changed or if Todos are missing
         const updatedRoleTodoMap: RoleTodoMap = handleTodosForExistingRow(row);
         const scheduleEntryId: string = handleScheduleEntryForExistingRow(row, updatedRoleTodoMap);
         saveRow(row, updatedRoleTodoMap, scheduleEntryId);
     } else if(isMissingScheduleEntry(row)) {
+        // Create the Schedule Entry if it is missing
         const roleTodoMap: RoleTodoMap = getRoleTodoMap(row);
         const scheduleEntryId: string = handleScheduleEntryForExistingRow(row, roleTodoMap);
         saveRow(row, roleTodoMap, scheduleEntryId);
@@ -73,10 +75,12 @@ function handleScheduleEntryForExistingRow(row: Row, updatedRoleTodoMap: RoleTod
     let scheduleEntryId: string = getSavedScheduleEntryId(row);
     
     if(scheduleEntryId !== "") {
+        // Update the Schedule Entry if it exists
         const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, updatedRoleTodoMap);
         const scheduleEntryIdentifier: ScheduleEntryIdentifier = getScheduleEntryIdentifier(scheduleEntryId);
         updateScheduleEntry(scheduleEntryRequest, scheduleEntryIdentifier);
     } else {
+        // Create the Schedule Entry if it is missing
         scheduleEntryId = createScheduleEntryForRow(row, updatedRoleTodoMap);
     }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
-import { getRoleTodoMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow, isMissingScheduleEntry, isMissingTodos } from "./row";
+import { getRoleTodoMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow, isMissingScheduleEntry, isMissingTodos, toString } from "./row";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
 import { getEventRowsFromSpreadsheet } from "./scan";
 import { createScheduleEntryForRow, deleteScheduleEntry, getScheduleEntryIdentifier, updateScheduleEntry } from "./schedule";
@@ -78,7 +78,12 @@ function handleScheduleEntryForExistingRow(row: Row, updatedRoleTodoMap: RoleTod
         // Update the Schedule Entry if it exists
         const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, updatedRoleTodoMap);
         const scheduleEntryIdentifier: ScheduleEntryIdentifier = getScheduleEntryIdentifier(scheduleEntryId);
-        updateScheduleEntry(scheduleEntryRequest, scheduleEntryIdentifier);
+
+        try {
+            updateScheduleEntry(scheduleEntryRequest, scheduleEntryIdentifier);
+        } catch (error: any) {
+            Logger.log(`Error updating schedule entry for row ${toString(row)}: ${error}`);
+        }
     } else {
         // Create the Schedule Entry if it is missing
         scheduleEntryId = createScheduleEntryForRow(row, updatedRoleTodoMap);
@@ -122,7 +127,12 @@ function deleteOldRows(processedRowIds: string[]): void {
             if(isInFuture(rowDate)) {
                 const scheduleEntryId: string = rowBasecampMapping.scheduleEntryId;
                 const scheduleEntryIdentifier: ScheduleEntryIdentifier = getScheduleEntryIdentifier(scheduleEntryId);
-                deleteScheduleEntry(scheduleEntryIdentifier);
+
+                try {
+                    deleteScheduleEntry(scheduleEntryIdentifier);
+                } catch (error: any) {
+                    Logger.log(`Error deleting schedule entry for row ${rowId}: ${error}`);
+                }
             }
 
             deleteDocumentProperty(rowId);

--- a/src/main/retry.ts
+++ b/src/main/retry.ts
@@ -2,26 +2,47 @@ import { RetryError } from "./error/retryError";
 
 type URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;
 
+const HTTP_200_RESPONSE_CODE: number = 200;
+const HTTP_300_RESPONSE_CODE: number = 300;
+const HTTP_400_RESPONSE_CODE: number = 400;
+const HTTP_500_RESPONSE_CODE: number = 500;
+
 export function fetchWithRetry(url: string, options: URLFetchRequestOptions, maxRetries: number = 3, baseDelay: number = 1000): HTTPResponse {
     let attempt = 0;
   
     while (attempt < maxRetries) {
-        try {
-            return UrlFetchApp.fetch(url, options);
-        } catch (error: any) {
-            Logger.log(`WARN: Attempt ${attempt + 1} failed: ${error.message}`);
+        // Don't throw an exception on HTTP errors so we can handle them ourselves
+        options.muteHttpExceptions = true;
+
+        const response: HTTPResponse = UrlFetchApp.fetch(url, options);
+
+        if(is2xxResponse(response)) {
+            return response;
+        } else if(is4xxResponse(response)) {
+            Logger.log(`WARN: Attempt ${attempt + 1} failed but not retrying: ${response.getResponseCode()} ${response.getContentText()}`);
+            return response;
+        } else {
+            Logger.log(`WARN: Attempt ${attempt + 1} failed: ${response.getResponseCode()} ${response.getContentText()}`);
   
             if (attempt === maxRetries - 1) {
-                throw new RetryError(`Failed after ${maxRetries} attempts: ${error.message}`);
+                throw new RetryError(`Failed after ${maxRetries} attempts: ${response.getResponseCode()} ${response.getContentText()}`);
             }
-  
+
             // Exponential backoff: delay increases on each retry
             const delay: number = baseDelay * Math.pow(2, attempt);
             Utilities.sleep(delay);
+    
+            attempt++;
         }
-  
-        attempt++;
     }
 
     return UrlFetchApp.fetch(url, options);
+}
+
+function is2xxResponse(response: HTTPResponse): boolean {
+    return response.getResponseCode() >= HTTP_200_RESPONSE_CODE && response.getResponseCode() < HTTP_300_RESPONSE_CODE;
+}
+
+function is4xxResponse(response: HTTPResponse): boolean {
+    return response.getResponseCode() >= HTTP_400_RESPONSE_CODE && response.getResponseCode() < HTTP_500_RESPONSE_CODE;
 }

--- a/src/main/retry.ts
+++ b/src/main/retry.ts
@@ -1,0 +1,27 @@
+import { RetryError } from "./error/retryError";
+
+type URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;
+
+export function fetchWithRetry(url: string, options: URLFetchRequestOptions, maxRetries: number = 3, baseDelay: number = 1000): HTTPResponse {
+    let attempt = 0;
+  
+    while (attempt < maxRetries) {
+        try {
+            return UrlFetchApp.fetch(url, options);
+        } catch (error: any) {
+            Logger.log(`WARN: Attempt ${attempt + 1} failed: ${error.message}`);
+  
+            if (attempt === maxRetries - 1) {
+                throw new RetryError(`Failed after ${maxRetries} attempts: ${error.message}`);
+            }
+  
+            // Exponential backoff: delay increases on each retry
+            const delay: number = baseDelay * Math.pow(2, attempt);
+            Utilities.sleep(delay);
+        }
+  
+        attempt++;
+    }
+
+    return UrlFetchApp.fetch(url, options);
+}

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -707,6 +707,22 @@ export function getSavedScheduleEntryId(row: Row): string {
     return savedRowBasecampMapping.scheduleEntryId;
 }
 
+export function isMissingTodos(row: Row): boolean {
+    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
+    if(savedRowBasecampMapping === null) {
+        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
+    }
+    return Object.values(savedRowBasecampMapping.roleTodoMap).length === 0;
+}
+
+export function isMissingScheduleEntry(row: Row): boolean {
+    const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
+    if(savedRowBasecampMapping === null) {
+        throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
+    }
+    return savedRowBasecampMapping.scheduleEntryId === "";
+}
+
 export function hasBasecampAttendees(row: Row): boolean {
     return getBasecampIdsFromPersonNameList(getAttendeesFromRow(row)).length > 0;
 }

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -92,7 +92,7 @@ export function hasId(row: Row): boolean {
  * @param roleTodoMap a map that has role titles as the keys and todo objects as the values
  * @param scheduleEntryId id of the schedule entry created for this row
  */
-export function saveRow(row: Row, roleTodoMap: RoleTodoMap, scheduleEntryId: string): void {
+export function saveRow(row: Row, roleTodoMap: RoleTodoMap, scheduleEntryId: string | undefined): void {
     if(!hasId(row)) {
         throw new RowMissingIdError(`Row does not have an id: ${toString(row)}`);
     }
@@ -721,7 +721,7 @@ export function getRoleTodoMap(row: Row): RoleTodoMap {
     return savedRowBasecampMapping.roleTodoMap;
 }
 
-export function getSavedScheduleEntryId(row: Row): string {
+export function getSavedScheduleEntryId(row: Row): string | undefined {
     const savedRowBasecampMapping: RowBasecampMapping | null = getRowBasecampMapping(row);
     if(savedRowBasecampMapping === null) {
         throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
@@ -743,7 +743,7 @@ export function isMissingScheduleEntry(row: Row): boolean {
     if(savedRowBasecampMapping === null) {
         throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
     }
-    return savedRowBasecampMapping.scheduleEntryId === "";
+    return savedRowBasecampMapping.scheduleEntryId === undefined;
 }
 
 export function hasBasecampAttendees(row: Row): boolean {

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -210,6 +210,17 @@ function toHexString(byteArray: number[]): string {
     .join('');
 }
 
+function getNumTodosForRow(row: Row): number {
+    const leadIds: string[] = getLeadsBasecampIds(row);
+    const numLeadsTodos: number = leadIds.length > 0 ? 1 : 0;
+    const helperGroups: HelperGroup[] = getHelperGroups(row);
+
+    return helperGroups.reduce((numTodos, helperGroup) => {
+        const helperIds: string[] = helperGroup.helperIds.filter(id => !leadIds.includes(id));
+        return helperIds.length > 0 ? numTodos + 1 : numTodos;
+    }, numLeadsTodos);
+}
+
 /**
  * Retrieves an array of BasecampTodoRequest objects for an event row. BasecampTodoRequest
  * objects are constructed for both the leads and the helpers
@@ -712,7 +723,7 @@ export function isMissingTodos(row: Row): boolean {
     if(savedRowBasecampMapping === null) {
         throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
     }
-    const numExpectedTodos: number = Object.values(getBasecampTodoRequestsForRow(row)).length;
+    const numExpectedTodos: number = getNumTodosForRow(row);
     return Object.values(savedRowBasecampMapping.roleTodoMap).length !== numExpectedTodos;
 }
 

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -712,7 +712,8 @@ export function isMissingTodos(row: Row): boolean {
     if(savedRowBasecampMapping === null) {
         throw new RowBasecampMappingMissingError("The rowBasecampMapping object is null!");
     }
-    return Object.values(savedRowBasecampMapping.roleTodoMap).length === 0;
+    const numExpectedTodos: number = Object.values(getBasecampTodoRequestsForRow(row)).length;
+    return Object.values(savedRowBasecampMapping.roleTodoMap).length !== numExpectedTodos;
 }
 
 export function isMissingScheduleEntry(row: Row): boolean {

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -210,13 +210,20 @@ function toHexString(byteArray: number[]): string {
     .join('');
 }
 
+/**
+ * Returns the number of todos for a given row. Used to determine if there are any 
+ * missing Todos
+ * 
+ * @param row row to calculate the number of todos for
+ * @returns the number of todos for the given row
+ */
 function getNumTodosForRow(row: Row): number {
     const leadIds: string[] = getLeadsBasecampIds(row);
     const numLeadsTodos: number = leadIds.length > 0 ? 1 : 0;
     const helperGroups: HelperGroup[] = getHelperGroups(row);
 
     return helperGroups.reduce((numTodos, helperGroup) => {
-        const helperIds: string[] = helperGroup.helperIds.filter(id => !leadIds.includes(id));
+        const helperIds: string[] = getHelperIdsWithoutLeads(helperGroup, leadIds);
         return helperIds.length > 0 ? numTodos + 1 : numTodos;
     }, numLeadsTodos);
 }
@@ -385,7 +392,7 @@ export function getBasecampTodosForHelpers(row: Row): RoleRequestMap {
         const roleTitle: string = helperGroup.role ? `${helperGroup.role} Helper` : "Helper";
         const basecampTodoContent: string = `${roleTitle}: ${row.what.value}`;
         const basecampTodoDescription: string = getBasecampTodoDescription(row);
-        const assigneeIds = helperGroup.helperIds.filter(id => !leadIds.includes(id));
+        const assigneeIds = getHelperIdsWithoutLeads(helperGroup, leadIds);
         const basecampDueDate: string = getBasecampDueDate(row);
 
         if(assigneeIds.length > 0) {
@@ -398,6 +405,10 @@ export function getBasecampTodosForHelpers(row: Row): RoleRequestMap {
     }
 
     return helperRoleRequestMap;
+}
+
+function getHelperIdsWithoutLeads(helperGroup: HelperGroup, leadIds: string[]): string[] {
+    return helperGroup.helperIds.filter(id => !leadIds.includes(id));
 }
 
 /**

--- a/src/main/schedule.ts
+++ b/src/main/schedule.ts
@@ -1,5 +1,6 @@
 import { BASECAMP_PROJECT_ID, BASECAMP_SCHEDULE_ID } from "../../config/environmentVariables";
 import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { getScheduleEntryRequestForRow, toString } from "./row";
 
 const SCHEDULES_PATH: string = '/schedules/';
 const SCHEDULE_ENTRIES: string = '/schedule_entries/';
@@ -79,4 +80,16 @@ function getUpdateScheduleEntryUrl(scheduleEntryIdentifier: ScheduleEntryIdentif
 
 function getDeleteScheduleEntryUrl(scheduleEntryIdentifier: ScheduleEntryIdentifier): string {
     return getBasecampProjectUrl(scheduleEntryIdentifier.projectId) + RECORDINGS_PATH + scheduleEntryIdentifier.scheduleEntryId + TRASHED_STATUS_JSON_PATH;
+}
+
+export function createScheduleEntryForRow(row: Row, roleTodoMap: RoleTodoMap): string {
+    const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, roleTodoMap);
+    let scheduleEntryId: string = "";
+    try {
+        scheduleEntryId = createScheduleEntry(scheduleEntryRequest, getDefaultScheduleIdentifier());
+    } catch(error: any) {
+        Logger.log(`Error creating schedule entry for ${toString(row)}: ${error}`);
+    }
+
+    return scheduleEntryId;
 }

--- a/src/main/schedule.ts
+++ b/src/main/schedule.ts
@@ -82,9 +82,9 @@ function getDeleteScheduleEntryUrl(scheduleEntryIdentifier: ScheduleEntryIdentif
     return getBasecampProjectUrl(scheduleEntryIdentifier.projectId) + RECORDINGS_PATH + scheduleEntryIdentifier.scheduleEntryId + TRASHED_STATUS_JSON_PATH;
 }
 
-export function createScheduleEntryForRow(row: Row, roleTodoMap: RoleTodoMap): string {
+export function createScheduleEntryForRow(row: Row, roleTodoMap: RoleTodoMap): string | undefined {
     const scheduleEntryRequest: BasecampScheduleEntryRequest = getScheduleEntryRequestForRow(row, roleTodoMap);
-    let scheduleEntryId: string = "";
+    let scheduleEntryId: string | undefined = undefined;
     try {
         scheduleEntryId = createScheduleEntry(scheduleEntryRequest, getDefaultScheduleIdentifier());
     } catch(error: any) {

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -95,8 +95,12 @@ export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoMap {
 
     Object.keys(roleRequestMap).forEach( role => {
         let request: BasecampTodoRequest = roleRequestMap[role];
-        let basecampTodo: BasecampTodo = createTodo(request, getDefaultTodoListIdentifier());
-        roleTodoMap[role] = basecampTodo;
+        try {
+            let basecampTodo: BasecampTodo = createTodo(request, getDefaultTodoListIdentifier());
+            roleTodoMap[role] = basecampTodo;
+        } catch(error: any) {
+            Logger.log(`Error creating todo for role ${role}: ${error}`);
+        }
     });
 
     return roleTodoMap;

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -120,7 +120,11 @@ export function deleteTodos(todoIds: string[]): void {
             todoId: id
         }
 
-        deleteTodo(todoIdentifier);
+        try {
+            deleteTodo(todoIdentifier);
+        } catch(error: any) {
+            Logger.log(`Error deleting todo with id ${id}: ${error}`);
+        }
     }
 }
 
@@ -196,9 +200,12 @@ export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMa
             todoId: existingTodo.id
         };
 
-        updateTodo(request, todoIdentifier);
-
-        existingRoleTodoMap[role] = existingTodo;
+        try {
+            updateTodo(request, todoIdentifier);
+            existingRoleTodoMap[role] = existingTodo;
+        } catch(error: any) {
+            Logger.log(`Error updating todo for role ${role}: ${error}`);
+        }
     }
 
     return existingRoleTodoMap;
@@ -226,8 +233,12 @@ export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, la
                 throw new BasecampRequestMissingError("Missing basecamp request!");
             }
 
-            let newTodoId = createTodo(request, getDefaultTodoListIdentifier());
-            newRoleTodoMap[role] = newTodoId;
+            try {
+                let newTodoId = createTodo(request, getDefaultTodoListIdentifier());
+                newRoleTodoMap[role] = newTodoId;
+            } catch(error: any) {
+                Logger.log(`Error creating todo for role ${role}: ${error}`);
+            }
         }
 
     } else {

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -52,7 +52,7 @@ declare interface TabInfo {
 declare interface RowBasecampMapping {
   rowHash: string,
   roleTodoMap: RoleTodoMap
-  scheduleEntryId: string,
+  scheduleEntryId?: string,
   tabInfo: TabInfo
 }
 


### PR DESCRIPTION
Adds resiliency for HTTP exceptions when calling the Basecamp API with the following:
* Use retries with exponential backoff (courtesy of ChatGPT)
  * Note: Unit testing for this is objectively not the best. I don't know how to unit test exponential backoff
  * 4xx errors are not retried
* All API calls wrapped with try/catch to not halt execution on an exception 
* If a row has not changed but it is missing Todos (implies at least one Todo was failed to be created last run), then run the existing logic to delete obsolete todos, update current ones, and create missing ones
* If a row has not changed and there are no missing todos but the schedule entry is missing, create the new schedule entry
* If at any point the schedule entry needs to be updated but it is missing, create the missing one