### PR TITLE
ignore domain for attendees if rotation or various

### DIFF
--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -506,6 +506,88 @@ describe('getAttendeesFromRow', () => {
 
         expect(result).toEqual(['john doe', 'brian lin', 'james lee', 'jack zhang', 'angel zhang']);
     });
+
+    it('should ignore domain when attendees is rotation', () => {
+        const row: Row = getRandomlyGeneratedRow();
+        row.domain = "int'l";
+        row.who = "rotation";
+        row.inCharge.value = "john doe";
+        row.helpers.value = "";
+
+        // Mocked GROUPS_MAP
+        const MOCK_GROUPS_MAP = {
+            "int'l": ['brian lin', 'james lee', 'jack zhang', 'angel zhang'],
+        };
+
+        // Mocked MEMBER MAP
+        const MOCK_MEMBER_MAP = {
+            "brian lin": {"gender": "Male"},
+            "james lee": {"gender": "Male"},
+            "jack zhang": {"gender": "Male"},
+            "angel zhang": {"gender": "Female"},
+            "john doe": {"gender": "Male"},
+        };
+
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return MOCK_MEMBER_MAP;
+
+                } else if (key === "GROUPS_MAP") {
+                    return MOCK_GROUPS_MAP;
+                } else {
+                    return {};
+                }
+            }),
+        }));
+
+        const { getAttendeesFromRow } = require("../src/main/row");
+
+        const result = getAttendeesFromRow(row);
+
+        expect(result).toEqual(['john doe']);
+    });
+
+    it('should ignore domain when attendees is various', () => {
+        const row: Row = getRandomlyGeneratedRow();
+        row.domain = "int'l";
+        row.who = "various";
+        row.inCharge.value = "john doe";
+        row.helpers.value = "";
+
+        // Mocked GROUPS_MAP
+        const MOCK_GROUPS_MAP = {
+            "int'l": ['brian lin', 'james lee', 'jack zhang', 'angel zhang'],
+        };
+
+        // Mocked MEMBER MAP
+        const MOCK_MEMBER_MAP = {
+            "brian lin": {"gender": "Male"},
+            "james lee": {"gender": "Male"},
+            "jack zhang": {"gender": "Male"},
+            "angel zhang": {"gender": "Female"},
+            "john doe": {"gender": "Male"},
+        };
+
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "MEMBER_MAP") {
+                    return MOCK_MEMBER_MAP;
+
+                } else if (key === "GROUPS_MAP") {
+                    return MOCK_GROUPS_MAP;
+                } else {
+                    return {};
+                }
+            }),
+        }));
+
+        const { getAttendeesFromRow } = require("../src/main/row");
+
+        const result = getAttendeesFromRow(row);
+
+        expect(result).toEqual(['john doe']);
+    });
 });
 
 

--- a/src/main/aliases.ts
+++ b/src/main/aliases.ts
@@ -14,7 +14,7 @@ export function mergeAliasMaps(firstAliasMap: AliasMap, secondAliasMap: AliasMap
     const aliases: string[] = Object.keys(secondAliasMap);
     for(const alias of aliases) {
         if(finalAliasMap.hasOwnProperty(alias)) {
-            Logger.log(`Warning: Duplicate alias ${alias} detected`);
+            Logger.log(`WARN: Duplicate alias ${alias} detected`);
             finalAliasMap[alias] = finalAliasMap[alias].concat(secondAliasMap[alias]);
         } else {
             finalAliasMap[alias] = secondAliasMap[alias];

--- a/src/main/groups.ts
+++ b/src/main/groups.ts
@@ -106,7 +106,7 @@ function addGroupAliasesToMap(groupsAliasMap: AliasMap, groupAliases: string[], 
 
     for(const alias of groupAliases) {
         if(groupsAliasMap.hasOwnProperty(alias)) {
-            Logger.log(`Warning: Duplicate alias ${alias} detected`);
+            Logger.log(`WARN: Duplicate alias ${alias} detected`);
             newGroupsAliasMap[alias] = newGroupsAliasMap[alias].concat(groupMemberNames);
         } else {
             newGroupsAliasMap[alias] = [...groupMemberNames];
@@ -259,7 +259,7 @@ function mergeGroupsMaps(firstGroupsMap: GroupsMap, secondGroupsMap: GroupsMap):
     const groups: string[] = Object.keys(secondGroupsMap);
     for(const group of groups) {
         if(finalGroupsMap.hasOwnProperty(group)) {
-            Logger.log(`Warning: Duplicate group ${group} detected`);
+            Logger.log(`WARN: Duplicate group ${group} detected`);
             finalGroupsMap[group] = finalGroupsMap[group].concat(secondGroupsMap[group]);
         } else {
             finalGroupsMap[group] = secondGroupsMap[group];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,6 +47,7 @@ export function importOnestopToBasecamp(): void {
 function processExistingRow(row: Row): void {
 
     if(hasChanged(row) || isMissingTodos(row)) {
+        Logger.log("Row has changed, or is missing todos. Updating...");
         // Update Todos and Schedule Entry if the row has changed or if Todos are missing
         const updatedRoleTodoMap: RoleTodoMap = handleTodosForExistingRow(row);
         const scheduleEntryId: string | undefined = handleScheduleEntryForExistingRow(row, updatedRoleTodoMap);


### PR DESCRIPTION
we forgot to ignore the domain column if the attendees is rotation or various, and it sets the whole domain as attendees. fixing that.

also snuck in:
- cleaning up some warning logs