### PR TITLE
Allow addition of hyperlinks to trigger row updates

### DIFF
--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -196,8 +196,8 @@ export function getRowBasecampMapping(row: Row): RowBasecampMapping | null {
  * @returns string representation of the given row
  */
 export function toString(row: Row): string {
-    return `[${row.startTime}, ${row.endTime}, ${row.domain}, ${row.who}, ${row.numAttendees}, ${row.what.value}, 
-    ${row.where.value}, ${row.inCharge.value}, ${row.helpers.value}, ${row.notes.value}]`;
+    return `[${row.startTime}, ${row.endTime}, ${row.domain}, ${row.who}, ${row.numAttendees}, ${JSON.stringify(row.what)}, 
+    ${JSON.stringify(row.where)}, ${JSON.stringify(row.inCharge)}, ${JSON.stringify(row.helpers)}, ${JSON.stringify(row.notes)}]`;
 }
 
 /**


### PR DESCRIPTION
This PR updates the toString() function which is used to calculate the row hash to determine if a row has changed to factor in hyperlink and strikethrough data. This allows changes to rows that affect hyperlinks or strikethrough but do not change the text contents of the rows to still trigger row updates.

Note: Updating the row hash algorithm will trigger an update for all existing rows on the next run