### PR TITLE
Halt execution on basecamp auth error

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -3,6 +3,7 @@ global.Logger = Logger;
 
 import randomstring from "randomstring";
 import { getRandomlyGeneratedRoleRequestMap, getRandomlyGeneratedRoleTodoMap, getRandomlyGeneratedRow, getRandomlyGeneratedRowBasecampMapping, getRandomlyGeneratedScheduleEntryRequest, getRandomlyGeneratedScheduleEntryIdentifier, getRandomlyGeneratedScheduleIdentifier, Mock, getRandomlyGeneratedBasecampScheduleEntry } from "./testUtils";
+import { BasecampUnauthError } from '../src/main/error/basecampUnauthError';
 
 describe("importOnestopToBasecamp", () => {
     it("should create new Todos and Schedule Entries when a row is new", () => {
@@ -22,6 +23,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
@@ -108,6 +113,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
@@ -204,6 +213,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
@@ -324,6 +337,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
@@ -447,6 +464,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
 
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
+
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
         jest.mock("../src/main/scan", () => ({
@@ -563,6 +584,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
 
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
+
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
         jest.mock("../src/main/scan", () => ({
@@ -651,6 +676,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock2]: rowBasecampMappingMock2,
         };
 
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
+
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => []);
 
         jest.mock("../src/main/scan", () => ({
@@ -701,6 +730,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock1]: rowBasecampMappingMock1,
             [rowIdMock2]: rowBasecampMappingMock2,
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => []);
 
@@ -759,6 +792,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock2]: rowBasecampMappingMock2,
         };
 
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
+
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => []);
 
         jest.mock("../src/main/scan", () => ({
@@ -811,6 +848,10 @@ describe("importOnestopToBasecamp", () => {
         const documentPropertiesMock: DocumentProperties = {
             [rowIdMock1]: getRandomlyGeneratedRowBasecampMapping(),
         };
+
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
 
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1]);
 
@@ -891,6 +932,10 @@ describe("importOnestopToBasecamp", () => {
             [rowIdMock2]: getRandomlyGeneratedRowBasecampMapping(),
         };
 
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn(),
+        }));
+
         const getEventRowsFromSpreadsheetMock: Mock = jest.fn(() => [rowMock1, rowMock2]);
 
         jest.mock("../src/main/scan", () => ({
@@ -964,5 +1009,20 @@ describe("importOnestopToBasecamp", () => {
         expect(addBasecampLinkToRowMock).toHaveBeenNthCalledWith(2, rowMock2, scheduleEntryMock2.url);
         expect(generateIdForRowMock).toHaveBeenNthCalledWith(2, rowMock2);
         expect(saveRowMock).toHaveBeenNthCalledWith(2, rowMock2, roleTodoMapMock2, scheduleEntryMock2.id);
+    });
+
+    it("should throw an error when Basecamp is not authorized", () => {
+        jest.mock("../src/main/basecamp", () => ({
+            verifyBasecampAuthorization: jest.fn().mockImplementation(() => {
+                throw new BasecampUnauthError("Basecamp not authorized");
+            })
+        }));
+
+        jest.mock("../src/main/propertiesService", () => ({
+            loadMapFromScriptProperties: jest.fn(() => ({})),
+        }));
+
+        const { importOnestopToBasecamp } = require("../src/main/main");
+        expect(() => importOnestopToBasecamp()).toThrow(BasecampUnauthError);
     });
 });

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "randomstring": "^1.3.0",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.1",
-    "typescript": "^5.5.4",
-    "typescript-eslint": "^8.1.0",
+    "typescript": "5.7.3",
+    "typescript-eslint": "8.25.0",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4"
   }

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -129,6 +129,10 @@ export function checkAuthorization(): void {
     Logger.log(sendBasecampGetRequest(BASECAMP_AUTH_CHECK_URL));
 }
 
+export function verifyBasecampAuthorization(): void {
+    getValidatedBasecampService();
+}
+
 /**
  * Gets the OAuth service to interact with Basecamp.
  * "Unvalidated" because there may not be an active access token, see getValidatedBasecampService()

--- a/src/main/basecamp.ts
+++ b/src/main/basecamp.ts
@@ -1,4 +1,5 @@
 import { BASECAMP_CLIENT_ID, BASECAMP_CLIENT_SECRET } from "../../config/environmentVariables";
+import { BasecampUnauthError } from "./error/basecampUnauthError";
 import { fetchWithRetry } from "./retry";
 
 type HttpMethod = GoogleAppsScript.URL_Fetch.HttpMethod;
@@ -119,6 +120,12 @@ export function logout(): void {
 }
 
 export function checkAuthorization(): void {
+    const basecampService: OAuth2 = getUnvalidatedBasecampService();
+
+    if (!basecampService.hasAccess()) {
+        showAuthorizationDialog(basecampService.getAuthorizationUrl());
+    }
+
     Logger.log(sendBasecampGetRequest(BASECAMP_AUTH_CHECK_URL));
 }
 
@@ -152,8 +159,7 @@ function getValidatedBasecampService(): OAuth2 {
     if (basecampService.hasAccess()) {
         return basecampService;
     } else {
-        showAuthorizationDialog(basecampService.getAuthorizationUrl());
-        throw new Error(BASECAMP_UNAUTH_ERROR_MSG);
+        throw new BasecampUnauthError(BASECAMP_UNAUTH_ERROR_MSG);
     }
 }
 

--- a/src/main/error/basecampUnauthError.ts
+++ b/src/main/error/basecampUnauthError.ts
@@ -1,0 +1,9 @@
+export class BasecampUnauthError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BasecampUnauthError";
+
+        // Fix the prototype chain to ensure proper inheritance so the instanceOf check is reliable
+        Object.setPrototypeOf(this, BasecampUnauthError.prototype);
+    }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,4 @@
+import { verifyBasecampAuthorization } from "./basecamp";
 import { BasecampUnauthError } from "./error/basecampUnauthError";
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
 import { addBasecampLinkToRow, getRoleTodoMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow, hasBeenPreviouslyDeleted, isMissingScheduleEntry, isMissingTodos, toString } from "./row";
@@ -12,6 +13,7 @@ import { createNewTodos, createTodosForNewRoles, deleteObsoleteTodos, deleteTodo
  * create a menu item to give users the ability to manually trigger the import process. 
  */
 export function importOnestopToBasecamp(): void {
+    verifyBasecampAuthorization();
 
     const eventRows: Row[] = getEventRowsFromSpreadsheet();
     const processedRowIds: string[] = [];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,4 @@
+import { BasecampUnauthError } from "./error/basecampUnauthError";
 import { deleteDocumentProperty, getAllDocumentProperties } from "./propertiesService";
 import { addBasecampLinkToRow, getRoleTodoMap, getSavedScheduleEntryId, getScheduleEntryRequestForRow, hasBeenPreviouslyDeleted, isMissingScheduleEntry, isMissingTodos, toString } from "./row";
 import { generateIdForRow, getBasecampTodoRequestsForRow, getId, hasChanged, hasId, saveRow } from "./row";
@@ -84,6 +85,9 @@ function handleScheduleEntryForExistingRow(row: Row, updatedRoleTodoMap: RoleTod
         try {
             updateScheduleEntry(scheduleEntryRequest, scheduleEntryIdentifier);
         } catch (error: any) {
+            if(error instanceof BasecampUnauthError) {
+                throw error;
+            }
             Logger.log(`Error updating schedule entry for row ${toString(row)}: ${error}`);
         }
     } else {
@@ -144,6 +148,9 @@ function deleteOldRows(processedRowIds: string[]): void {
                 try {
                     deleteScheduleEntry(scheduleEntryIdentifier);
                 } catch (error: any) {
+                    if(error instanceof BasecampUnauthError) {
+                        throw error;
+                    }
                     Logger.log(`Error deleting schedule entry for row ${rowId}: ${error}`);
                 }
             }

--- a/src/main/schedule.ts
+++ b/src/main/schedule.ts
@@ -1,5 +1,6 @@
 import { BASECAMP_PROJECT_ID, BASECAMP_SCHEDULE_ID } from "../../config/environmentVariables";
 import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
+import { BasecampUnauthError } from "./error/basecampUnauthError";
 import { getScheduleEntryRequestForRow, toString } from "./row";
 
 const SCHEDULES_PATH: string = '/schedules/';
@@ -87,7 +88,10 @@ export function createScheduleEntryForRow(row: Row, roleTodoMap: RoleTodoMap): B
     let basecampScheduleEntry: BasecampScheduleEntry | undefined = undefined;
     try {
         basecampScheduleEntry = createScheduleEntry(scheduleEntryRequest, getDefaultScheduleIdentifier());
-    } catch(error: any) {
+    } catch(error: any) {   
+        if(error instanceof BasecampUnauthError) {
+            throw error;
+        }
         Logger.log(`Error creating schedule entry for ${toString(row)}: ${error}`);
     }
 

--- a/src/main/todos.ts
+++ b/src/main/todos.ts
@@ -1,6 +1,7 @@
 import { BASECAMP_PROJECT_ID, BASECAMP_TODOLIST_ID } from "../../config/environmentVariables";
 import { getBasecampProjectUrl, sendBasecampPostRequest, sendBasecampPutRequest } from "./basecamp";
 import { BasecampRequestMissingError } from "./error/basecampRequestMissingError";
+import { BasecampUnauthError } from "./error/basecampUnauthError";
 import { TodoIdMissingError } from "./error/todoIdMissingError";
 import { getExistingRoles, getNewRoles, getRemovedRoles } from "./role";
 
@@ -99,6 +100,9 @@ export function createNewTodos(roleRequestMap: RoleRequestMap): RoleTodoMap {
             let basecampTodo: BasecampTodo = createTodo(request, getDefaultTodoListIdentifier());
             roleTodoMap[role] = basecampTodo;
         } catch(error: any) {
+            if(error instanceof BasecampUnauthError) {
+                throw error;
+            }
             Logger.log(`Error creating todo for role ${role}: ${error}`);
         }
     });
@@ -123,6 +127,9 @@ export function deleteTodos(todoIds: string[]): void {
         try {
             deleteTodo(todoIdentifier);
         } catch(error: any) {
+            if(error instanceof BasecampUnauthError) {
+                throw error;
+            }
             Logger.log(`Error deleting todo with id ${id}: ${error}`);
         }
     }
@@ -204,6 +211,9 @@ export function updateTodosForExistingRoles(currentRoleRequestMap: RoleRequestMa
             updateTodo(request, todoIdentifier);
             existingRoleTodoMap[role] = existingTodo;
         } catch(error: any) {
+            if(error instanceof BasecampUnauthError) {
+                throw error;
+            }
             Logger.log(`Error updating todo for role ${role}: ${error}`);
         }
     }
@@ -237,6 +247,9 @@ export function createTodosForNewRoles(currentRoleRequestMap: RoleRequestMap, la
                 let newTodoId = createTodo(request, getDefaultTodoListIdentifier());
                 newRoleTodoMap[role] = newTodoId;
             } catch(error: any) {
+                if(error instanceof BasecampUnauthError) {
+                    throw error;
+                }
                 Logger.log(`Error creating todo for role ${role}: ${error}`);
             }
         }


### PR DESCRIPTION
Throws an error to halt execution when Basecamp is unauthorized to prevent any unintended behavior from happening. Also fixes an issue with unpinned dependencies that started causing build errors after Typescript released a new version a couple days ago

Note: I cannot get the unit tests working for this. When the jest mock throws the error, the `instanceOf` check fails for some reason. I hardcoded throwing the error for testing but if someone can figure out the unit tests for this that would be helpful