### PR TITLE
Team table parsing

### DIFF
--- a/__test__/members.test.ts
+++ b/__test__/members.test.ts
@@ -7,12 +7,13 @@ global.SpreadsheetApp = SpreadsheetApp;
 import { getRandomlyGeneratedAliasTable, getRandomlyGeneratedMemberMap, getRandomlyGeneratedMemberTable, Mock } from './testUtils';
 import { PersonAliasClashError } from '../src/main/error/personAliasClashError';
 
-const NAME_COLUMN_INDEX: number = 0;
-const GENDER_COLUMN_INDEX: number = 1;
-const MARRIED_COLUMN_INDEX: number = 2;
-const PARENT_COLUMN_INDEX: number = 3;
-const CLASS_COLUMN_INDEX: number = 4;
-const ALTERNATE_NAMES_COLUMN_INDEX: number = 5;
+const NAME_COLUMN_INDEX: number = 28;
+const GENDER_COLUMN_INDEX: number = 4;
+const MARRIED_COLUMN_INDEX: number = 6;
+const PARENT_COLUMN_INDEX: number = 7;
+const CLASS_COLUMN_INDEX: number = 8;
+const ALTERNATE_NAMES_COLUMN_INDEX: number = 29;
+const BASECAMP_ID_COLUMN_INDEX: number = 30;
 
 describe("MEMBER_MAP", () => {
     it("should return the member map from the script properties when it is present", () => {
@@ -43,16 +44,21 @@ describe("MEMBER_MAP", () => {
 describe("loadMembersFromOnestopIntoScriptProperties", () => {
     it("should load the members and couples table from the onestop into the script properties when the members and couples table are present on the onestop", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(5, 1);
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
-        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "Mary Brown";
-        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
-        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "Robert White";
-        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "Robert,Robert W";
-        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "Emily White";
-        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "Emily,Emily W";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[3][GENDER_COLUMN_INDEX] = "M";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[4][GENDER_COLUMN_INDEX] = "M";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
+        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "Mary Brown";
+        membersDataValuesMock[5][GENDER_COLUMN_INDEX] = "F";
+        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
+        membersDataValuesMock[6][NAME_COLUMN_INDEX] = "Robert White";
+        membersDataValuesMock[6][GENDER_COLUMN_INDEX] = "M";
+        membersDataValuesMock[6][ALTERNATE_NAMES_COLUMN_INDEX] = "Robert,Robert W";
+        membersDataValuesMock[7][NAME_COLUMN_INDEX] = "Emily White";
+        membersDataValuesMock[7][GENDER_COLUMN_INDEX] = "F";
+        membersDataValuesMock[7][ALTERNATE_NAMES_COLUMN_INDEX] = "Emily,Emily W";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(2);
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "James/Mary,Browns"];
@@ -74,11 +80,11 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
         const receivedAliasMap: AliasMap = loadMembersFromOnestopIntoScriptProperties();
 
         const expectedMemberMap: MemberMap = {
-            "john doe": {name: "john doe", gender: membersDataValuesMock[1][GENDER_COLUMN_INDEX], married: membersDataValuesMock[1][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[1][PARENT_COLUMN_INDEX], class: membersDataValuesMock[1][CLASS_COLUMN_INDEX]},
-            "james brown": {name: "james brown", gender: membersDataValuesMock[2][GENDER_COLUMN_INDEX], married: membersDataValuesMock[2][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[2][PARENT_COLUMN_INDEX], class: membersDataValuesMock[2][CLASS_COLUMN_INDEX]},
-            "mary brown": {name: "mary brown", gender: membersDataValuesMock[3][GENDER_COLUMN_INDEX], married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX]},
-            "robert white": {name: "robert white", gender: membersDataValuesMock[4][GENDER_COLUMN_INDEX], married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX]},
-            "emily white": {name: "emily white", gender: membersDataValuesMock[5][GENDER_COLUMN_INDEX], married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX]},
+            "john doe": {name: "john doe", gender: "Male", married: membersDataValuesMock[3][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[3][PARENT_COLUMN_INDEX], class: membersDataValuesMock[3][CLASS_COLUMN_INDEX], basecampId: membersDataValuesMock[3][BASECAMP_ID_COLUMN_INDEX]},
+            "james brown": {name: "james brown", gender: "Male", married: membersDataValuesMock[4][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[4][PARENT_COLUMN_INDEX], class: membersDataValuesMock[4][CLASS_COLUMN_INDEX], basecampId: membersDataValuesMock[4][BASECAMP_ID_COLUMN_INDEX]},
+            "mary brown": {name: "mary brown", gender: "Female", married: membersDataValuesMock[5][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[5][PARENT_COLUMN_INDEX], class: membersDataValuesMock[5][CLASS_COLUMN_INDEX], basecampId: membersDataValuesMock[5][BASECAMP_ID_COLUMN_INDEX]},
+            "robert white": {name: "robert white", gender: "Male", married: membersDataValuesMock[6][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[6][PARENT_COLUMN_INDEX], class: membersDataValuesMock[6][CLASS_COLUMN_INDEX], basecampId: membersDataValuesMock[6][BASECAMP_ID_COLUMN_INDEX]},
+            "emily white": {name: "emily white", gender: "Female", married: membersDataValuesMock[7][MARRIED_COLUMN_INDEX], parent: membersDataValuesMock[7][PARENT_COLUMN_INDEX], class: membersDataValuesMock[7][CLASS_COLUMN_INDEX], basecampId: membersDataValuesMock[7][BASECAMP_ID_COLUMN_INDEX]},
         };
 
         const expectedAliasMap: AliasMap = {
@@ -127,10 +133,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should load a object of just the member alternate names when the couples table is empty", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
 
@@ -166,10 +172,10 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
 
     it("should throw an error when multiple people share the same alternate name", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(2, 1);
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Doe";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "John Brown";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John B";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "John Doe";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John D";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "John Brown";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John B";
 
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(0);
 
@@ -191,12 +197,12 @@ describe("loadMembersFromOnestopIntoScriptProperties", () => {
     it("should map an alias to both a person and a couple when a person's alternate name is the same as a couple's alias", () => {
         const membersDataValuesMock: any[][] = getRandomlyGeneratedMemberTable(3, 1);
 
-        membersDataValuesMock[1][NAME_COLUMN_INDEX] = "John Miller";
-        membersDataValuesMock[1][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John M, JM";
-        membersDataValuesMock[2][NAME_COLUMN_INDEX] = "James Brown";
-        membersDataValuesMock[2][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
-        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "Mary Brown";
-        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
+        membersDataValuesMock[3][NAME_COLUMN_INDEX] = "John Miller";
+        membersDataValuesMock[3][ALTERNATE_NAMES_COLUMN_INDEX] = "John,John M, JM";
+        membersDataValuesMock[4][NAME_COLUMN_INDEX] = "James Brown";
+        membersDataValuesMock[4][ALTERNATE_NAMES_COLUMN_INDEX] = "James,James B";
+        membersDataValuesMock[5][NAME_COLUMN_INDEX] = "Mary Brown";
+        membersDataValuesMock[5][ALTERNATE_NAMES_COLUMN_INDEX] = "Mary,Mary B";
         
         const couplesDataValuesMock: any[][] = getRandomlyGeneratedAliasTable(1);
         couplesDataValuesMock[1] = ["James Brown", "Mary Brown", "JM"];

--- a/__test__/testUtils.ts
+++ b/__test__/testUtils.ts
@@ -265,6 +265,7 @@ export function getRandomlyGeneratedMember(): Member {
         married: getRandomBoolean(),
         parent: getRandomBoolean(),
         class: getRandomNumber(),
+        basecampId: randomstring.generate(),
     };
 }
 
@@ -279,11 +280,11 @@ export function getRandomlyGeneratedMemberMap(numMembers: number = 10): MemberMa
 }
 
 function getRandomlyGeneratedMemberRow(numAlternateNames: number = 3): any[] {
-    return [randomstring.generate(), randomstring.generate(), getRandomBoolean(), getRandomBoolean(), getRandomNumber(), Array.from({length: numAlternateNames}, () => randomstring.generate()).join(",")];
+    return [randomstring.generate(), randomstring.generate(), randomstring.generate(), randomstring.generate(), randomstring.generate(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomNumber(), randomstring.generate(), randomstring.generate(), randomstring.generate(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), getRandomBoolean(), randomstring.generate(), Array.from({length: numAlternateNames}, () => randomstring.generate()).join(","), randomstring.generate()];
 }
 
 export function getRandomlyGeneratedMemberTable(numMembers: number = 10, numAlternateNames: number = 3): any[][] {
-    const memberTable: any[][] = [["Name", "Gender", "Married", "Parent", "Class", "Alertnate Names (comma separated)"]];
+    const memberTable: any[][] = [[],[],["Key", "First Name", "Last Name", "Ministry", "Gender", "Student", "Married", "Parent", "Class", "Email", "Phone", "Birthday", "UCSD SWS", "Setup Lead (SWS)", "Setup Lead (MBS)", "Sound Mixing (Prayer Meeting)", "Sound Mixing (Small Event)", "Propre", "Camera Operator", "Switcher/Stream", "Lightboard", "House Lights", "Trailer (Lead)", "Trailer (Helper)", "Instruments", "Tables", "Stage Hand", "Name", "Aliases", "Basecamp ID"]];
     for(let i = 0; i < numMembers; i++) {
         memberTable.push(getRandomlyGeneratedMemberRow(numAlternateNames));
     }

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -6,12 +6,13 @@ import { getCellValues } from "./scan";
 
 const MEMBERS_TAB_NAME: string = "Members";
 const COUPLES_TAB_NAME: string = "Couples";
-const NAME_COLUMN_INDEX: number = 0;
-const GENDER_COLUMN_INDEX: number = 1;
-const MARRIED_COLUMN_INDEX: number = 2;
-const PARENT_COLUMN_INDEX: number = 3;
-const CLASS_COLUMN_INDEX: number = 4;
-const ALTERNATE_NAMES_COLUMN_INDEX: number = 5;
+const NAME_COLUMN_INDEX: number = 28;
+const GENDER_COLUMN_INDEX: number = 4;
+const MARRIED_COLUMN_INDEX: number = 6;
+const PARENT_COLUMN_INDEX: number = 7;
+const CLASS_COLUMN_INDEX: number = 8;
+const ALTERNATE_NAMES_COLUMN_INDEX: number = 29;
+const BASECAMP_ID_COLUMN_INDEX: number = 30;
 const HUSBAND_COLUMN_INDEX: number = 0;
 const WIFE_COLUMN_INDEX: number = 1;
 const COUPLES_ALIASES_COLUMN_INDEX: number = 2;
@@ -39,8 +40,8 @@ function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: Al
     const memberMap: MemberMap = {};
     let alternateNamesMap: AliasMap = {};
 
-    // Start at row 1 to skip the table header row
-    for(let i = 1; i < cellValues.length; i++) {
+    // Start at row 3 to skip the table header row
+    for(let i = 3; i < cellValues.length; i++) {
         const rowValues: any[] = cellValues[i];
         const currentMember: Member = constructMember(rowValues);
         memberMap[currentMember.name] = currentMember;
@@ -55,16 +56,21 @@ function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: Al
 function constructMember(rowValues: any): Member {
     return {
         name: normalizePersonName(rowValues[NAME_COLUMN_INDEX]),
-        gender: rowValues[GENDER_COLUMN_INDEX],
+        gender: getGender(rowValues[GENDER_COLUMN_INDEX]),
         married: rowValues[MARRIED_COLUMN_INDEX],
         parent: rowValues[PARENT_COLUMN_INDEX],
-        class: rowValues[CLASS_COLUMN_INDEX]
+        class: rowValues[CLASS_COLUMN_INDEX],
+        basecampId: rowValues[BASECAMP_ID_COLUMN_INDEX],
     };
+}
+
+function getGender(rowValue: any): string {
+    return rowValue === "M" ? "Male" : "Female";
 }
 
 function getAliasList(rowValues: any, index: number): string[] {
     const aliasList: string = rowValues[index];
-    return aliasList.split(COMMA_DELIMITER).map(alias => alias.trim());
+    return aliasList.split(COMMA_DELIMITER).map(alias => alias.trim()).filter(alias => alias !== "");
 }
 
 function addAlternateNamesToMap(alternateNamesMap: AliasMap, alternateNames: string[], currentMember: Member): AliasMap {

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -18,6 +18,8 @@ const WIFE_COLUMN_INDEX: number = 1;
 const COUPLES_ALIASES_COLUMN_INDEX: number = 2;
 const COMMA_DELIMITER: string = ",";
 const MEMBER_MAP_KEY: string = "MEMBER_MAP";
+const MALE_GENDER: string = "Male";
+const FEMALE_GENDER: string = "Female";
 
 export const MEMBER_MAP: MemberMap = loadMapFromScriptProperties(MEMBER_MAP_KEY) as MemberMap;
 
@@ -65,7 +67,7 @@ function constructMember(rowValues: any): Member {
 }
 
 function getGender(rowValue: any): string {
-    return rowValue === "M" ? "Male" : "Female";
+    return rowValue === "M" ? MALE_GENDER : FEMALE_GENDER;
 }
 
 function getAliasList(rowValues: any, index: number): string[] {

--- a/src/main/members.ts
+++ b/src/main/members.ts
@@ -20,6 +20,7 @@ const COMMA_DELIMITER: string = ",";
 const MEMBER_MAP_KEY: string = "MEMBER_MAP";
 const MALE_GENDER: string = "Male";
 const FEMALE_GENDER: string = "Female";
+const MEMBER_TABLE_FIRST_ROW: number = 3;
 
 export const MEMBER_MAP: MemberMap = loadMapFromScriptProperties(MEMBER_MAP_KEY) as MemberMap;
 
@@ -42,8 +43,8 @@ function loadMembersFromOnestop(): { memberMap: MemberMap, alternateNamesMap: Al
     const memberMap: MemberMap = {};
     let alternateNamesMap: AliasMap = {};
 
-    // Start at row 3 to skip the table header row
-    for(let i = 3; i < cellValues.length; i++) {
+    // Start at MEMBER_TABLE_FIRST_ROW to skip the table header rows
+    for(let i = MEMBER_TABLE_FIRST_ROW; i < cellValues.length; i++) {
         const rowValues: any[] = cellValues[i];
         const currentMember: Member = constructMember(rowValues);
         memberMap[currentMember.name] = currentMember;

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -1,6 +1,7 @@
 import { BASECAMP_PROJECT_ID } from "../../config/environmentVariables";
 import { getBasecampUrl, sendPaginatedBasecampGetRequest } from "./basecamp";
 import { PersonNameIdMapNotCachedError } from "./error/personNameIdMapNotCachedError";
+import { MEMBER_MAP } from "./members";
 import { getScriptProperty, setScriptProperty } from "./propertiesService";
 
 type PersonNameIdMap = {[key: string]: string};
@@ -46,7 +47,15 @@ function getPeoplePath(): string {
  * @returns the person's Basecamp id
  */
 export function getPersonId(personName: string): string | undefined {
-    const normalizedPersonName = normalizePersonName(personName);
+    const normalizedPersonName: string = normalizePersonName(personName);
+
+    // Pull the basecamp id from the member properties if possible
+    if(MEMBER_MAP.hasOwnProperty(normalizedPersonName)) {
+        return MEMBER_MAP[normalizedPersonName].basecampId;
+    }
+
+    // Otherwise fallback on the legacy method that relies on the basecamp people endpoint
+
     // Check the in memory cache first
     if(cachedPersonNameIdMap !== null) {
         const id: string | undefined = getPersonIdFromCache(normalizedPersonName);

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -50,12 +50,12 @@ export function getPersonId(personName: string): string | undefined {
     const normalizedPersonName: string = normalizePersonName(personName);
 
     // Pull the basecamp id from the member properties if possible
-    if(MEMBER_MAP.hasOwnProperty(normalizedPersonName)) {
+    if(MEMBER_MAP.hasOwnProperty(normalizedPersonName) && MEMBER_MAP[normalizedPersonName].basecampId !== "") {
         return MEMBER_MAP[normalizedPersonName].basecampId;
     }
 
     // Otherwise fallback on the legacy method that relies on the basecamp people endpoint
-    Logger.log("Falling back to legacy method to fetch person basecamp id");
+    Logger.log(`Falling back to legacy method to fetch basecamp id for ${normalizedPersonName}`);
 
     // Check the in memory cache first
     if(cachedPersonNameIdMap !== null) {

--- a/src/main/people.ts
+++ b/src/main/people.ts
@@ -55,6 +55,7 @@ export function getPersonId(personName: string): string | undefined {
     }
 
     // Otherwise fallback on the legacy method that relies on the basecamp people endpoint
+    Logger.log("Falling back to legacy method to fetch person basecamp id");
 
     // Check the in memory cache first
     if(cachedPersonNameIdMap !== null) {

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -157,7 +157,8 @@ declare interface Member {
   gender: string,
   married: boolean,
   parent: boolean,
-  class: number
+  class: number,
+  basecampId: string
 }
 
 // Maps a members name to their Member object containing their properties


### PR DESCRIPTION
First draft of parsing the team table. The basecamp id fetching logic has been updated to try and fetch the id from the member data read from the team table first. If it can't be fetched it will fall back on the existing id fetching logic from the people endpoint