### PR TITLE
Remove noisy log message

### DIFF
--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -303,13 +303,7 @@ function getBasecampLeadNames(row: Row): string[] {
  * @returns array of Basecamp ids
  */
 function getBasecampIdsFromPersonNameList(personNameList: string[]): string[] {
-    return personNameList.map((name) => {
-        const personId: string | undefined = getPersonId(name);
-        if (personId === undefined) {
-            Logger.log(`WARN: No Basecamp person ID found for: ${name}`);
-        }
-        return personId;
-    }).filter((personId) => personId !== undefined);
+    return personNameList.map((name) => getPersonId(name)).filter((personId) => personId !== undefined);
 }
 
 /**


### PR DESCRIPTION
This PR removes the noisy log message for missing basecamp ids for people
The team table parsing PR #65 adds the log message for when the person cannot be found from the Team tab and thus needs to fall back on the legacy way of looking up the basecamp id