### PR TITLE
fix ordering of filters

### DIFF
--- a/__test__/validation.test.ts
+++ b/__test__/validation.test.ts
@@ -105,6 +105,25 @@ describe("validateHelperCellText", () => {
         expect(validateHelperCellText("HG2 Bros")).toBe("");
     });
 
+    it("should allow for filter names that are part of another filter name", () => {
+        jest.mock('../src/main/propertiesService', () => ({
+            loadMapFromScriptProperties: jest.fn((key: string) => {
+                if (key === "GROUPS_MAP") {
+                    return {
+                        "hg2": ['andrew chan', 'janice chan']
+                    }
+                } 
+                return {};
+            }),
+        }));
+        const { validateHelperCellText } = require("../src/main/validation");
+
+        // "Sisters" has "Sis" in it, which may be extracted out and what remains is "ters"
+        expect(validateHelperCellText("HG2 Sisters")).toBe("");
+        // "Minus moms" has "Moms" in it, which may be extracted out and what remains is "minus"
+        expect(validateHelperCellText("HG2 Minus Moms")).toBe("");
+    });
+
     it("should report helper identifiers with invalid filters", () => {
         jest.mock('../src/main/propertiesService', () => ({
             loadMapFromScriptProperties: jest.fn((key: string) => {

--- a/src/main/filter.ts
+++ b/src/main/filter.ts
@@ -11,16 +11,16 @@ const SIS_GENDER: string = "Female";
 
 // Maps a filter's name on the Onestop to its corresponding filter function
 const FILTER_MAP: FilterMap = {
-    bros: brosFilter, 
     brothers: brosFilter,
-    sis: sisFilter,
+    bros: brosFilter, 
     sisters: sisFilter,
+    sis: sisFilter,
     married: marriedFilter,
     parents: parentsFilter,
-    moms: momsFilter,
-    dads: dadsFilter,
     "minus moms": minusMomsFilter,
     "minus dads": minusDadsFilter,
+    moms: momsFilter,
+    dads: dadsFilter,
 };
 
 /** Removes all filters from a string


### PR DESCRIPTION
fixes a silly bug where the order of the filter extractions during validation breaks when one filter is a substring of another filter.
e.g. "sis" will mess up "sisters", it turns into "ters". or "moms" breaks "minus moms" as it turns into "minus".

this is a hacky bandaid fix but it gets the job done.