### PR TITLE
store ppl and groups in row hash to detect changes

### DIFF
--- a/__test__/row.test.ts
+++ b/__test__/row.test.ts
@@ -644,6 +644,8 @@ describe("saveRow", () => {
     });
 
     it("should save the row to the document properties when called", () => {
+        jest.resetModules();
+
         const rowMock: Row = getRandomlyGeneratedRow();
         const metadataMock: Metadata = getRandomlyGeneratedMetadata();
         const roleTodoMapMock: RoleTodoMap = getRandomlyGeneratedRoleTodoMap();
@@ -664,6 +666,29 @@ describe("saveRow", () => {
         jest.mock("../src/main/propertiesService", () => ({
             setDocumentProperty: setDocumentPropertyMock,
             loadMapFromScriptProperties: jest.fn(() => ({})),
+            getScriptProperty: jest.fn(() => null),
+        }));
+
+        jest.mock("../src/main/people", () => ({
+            getPersonId: jest.fn(() => undefined),
+            normalizePersonName: (name: string) => name.toLowerCase().trim(),
+        }));
+
+        jest.mock("../src/main/aliases", () => ({
+            ALIASES_MAP: {},
+        }));
+
+        jest.mock("../src/main/groups", () => ({
+            GROUPS_MAP: {},
+            getMembersFromGroups: () => [],
+            GROUP_NAMES: [],
+        }));
+
+        jest.mock("../src/main/filter", () => ({
+            containsFilter: () => false,
+            removeFilters: (str: string) => ({ stringWithoutFilters: str, removedFilters: [] }),
+            filterMembers: (members: string[]) => members,
+            isFilter: () => false,
         }));
 
         const { saveRow } = require("../src/main/row");
@@ -911,7 +936,7 @@ describe("getHelperGroups", () => {
 
         const peopleToBasecampIdMap: { [name: string]: string } = {
             "john doe": randomstring.generate(),
-            "jane smith": randomstring.generate(),
+            "jane smith": randomstring.generate(), 
             "alice johnson": randomstring.generate(),
             "bob brown": randomstring.generate(),
         };
@@ -923,20 +948,44 @@ describe("getHelperGroups", () => {
 
         jest.mock("../src/main/groups", () => ({
             GROUPS_MAP: { "ucsd": ["john doe", "jane smith"] },
+            getMembersFromGroups: jest.fn(),
+            GROUP_NAMES: ["ucsd"],
         }));
 
         jest.mock("../src/main/people", () => ({
             normalizePersonName: jest.fn((personName) => personName.toLowerCase().trim()),
-            getPersonId: jest.fn((personName) => peopleToBasecampIdMap.hasOwnProperty(personName) ? peopleToBasecampIdMap[personName] : randomstring.generate()),
+            getPersonId: jest.fn((personName) => peopleToBasecampIdMap[personName.toLowerCase()] || undefined),
         }));
 
-        const expectedHelperGroups: HelperGroup[] = [
-            { role: "Food", helperIds: [peopleToBasecampIdMap["bob brown"], peopleToBasecampIdMap["alice johnson"], peopleToBasecampIdMap["john doe"]] }
-        ];
+        jest.mock("../src/main/filter", () => ({
+            containsFilter: jest.fn((str) => str.includes("bros")),  // lowercase since normalizePersonName converts to lowercase
+            removeFilters: jest.fn((str) => {
+                if (str.includes("bros")) {
+                    return { stringWithoutFilters: str.replace(" bros", ""), removedFilters: ["bros"] };
+                }
+                return { stringWithoutFilters: str, removedFilters: [] };
+            }),
+            filterMembers: jest.fn((members, filters) => {
+                if (filters.includes("bros")) {
+                    // Filter to only male members
+                    return members.filter((member: string) => memberMapMock[member]?.gender === "Male");
+                }
+                return members;
+            }),
+            isFilter: jest.fn((str) => str === "bros"),
+        }));
 
         const { getHelperGroups } = require("../src/main/row");
 
         const helperGroups: HelperGroup[] = getHelperGroups(rowMock);
+
+        const expectedHelperGroups: HelperGroup[] = [
+            { role: "Food", helperIds: [
+                peopleToBasecampIdMap["bob brown"],     // individual person 
+                peopleToBasecampIdMap["alice johnson"], // individual person (not filtered - listed directly)
+                peopleToBasecampIdMap["john doe"]       // from "UCSD Bros" (UCSD group filtered to males only)
+            ] }
+        ];
 
         expect(helperGroups).toStrictEqual(expectedHelperGroups);
     });

--- a/__test__/rowHash.test.ts
+++ b/__test__/rowHash.test.ts
@@ -1,0 +1,337 @@
+import randomstring from "randomstring";
+import { getRandomlyGeneratedRow, getRandomlyGeneratedMetadata } from "./testUtils";
+
+describe("hasChanged - Basecamp ID mapping", () => {
+    beforeEach(() => {
+        jest.resetModules();
+
+        // Stub global Logger used inside the row module
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        global.Logger = { log: jest.fn() };
+
+        // Stub for Utilities.computeDigest that produces a deterministic byte array based on
+        // the input string – changes in the string lead to changes in the resulting array.
+        // This allows us to detect hash input changes without needing crypto.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore – Utilities is injected globally in the production environment.
+        global.Utilities = {
+            DigestAlgorithm: { SHA_256: 0 },
+            computeDigest: (_algo: any, input: string) => input.split("").map((c) => c.charCodeAt(0)),
+        };
+    });
+
+    it("should return true when group membership changes affect lead resolution", () => {
+        // Mutable map so we can simulate updates to group membership after the row is saved
+        const groupMap: { [name: string]: string[] } = { 
+            "tech": ["john doe", "jane smith"]
+        };
+
+        // Static person → id mapping
+        const personIdMap: { [name: string]: string } = {
+            "john doe": "id1",
+            "jane smith": "id2",
+            "bob wilson": "id3"
+        };
+
+        jest.doMock("../src/main/people", () => ({
+            getPersonId: (name: string) => personIdMap[name.toLowerCase()],
+            normalizePersonName: (name: string) => name.toLowerCase().trim(),
+        }));
+
+        jest.doMock("../src/main/aliases", () => ({ ALIASES_MAP: {} }));
+
+        jest.doMock("../src/main/groups", () => ({
+            GROUPS_MAP: groupMap,
+            getMembersFromGroups: (groups: string[]) => {
+                return groups.flatMap(g => groupMap[g.toLowerCase()] || []);
+            },
+            GROUP_NAMES: ["tech"],
+        }));
+
+        jest.doMock("../src/main/filter", () => ({
+            containsFilter: () => false,
+            removeFilters: (str: string) => ({ stringWithoutFilters: str, removedFilters: [] }),
+            filterMembers: (members: string[]) => members,
+            isFilter: () => false,
+        }));
+
+        // PropertiesService mock that lets us capture what saveRow writes and return it later
+        let storedRowBasecampMapping: string | null = null;
+        jest.doMock("../src/main/propertiesService", () => ({
+            setDocumentProperty: (_k: string, v: string) => {
+                storedRowBasecampMapping = v;
+            },
+            getDocumentProperty: () => storedRowBasecampMapping,
+            loadMapFromScriptProperties: () => ({}),
+        }));
+
+        // Import module under test AFTER mocks are in place
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { saveRow, hasChanged } = require("../src/main/row");
+
+        // Construct a deterministic row with a group as lead
+        const row: Row = getRandomlyGeneratedRow();
+        row.inCharge.value = "Tech";
+        row.inCharge.tokens = [{ value: "Tech", hyperlink: null, strikethrough: false }];
+        row.domain = "Tech";  // This is needed for group resolution
+        row.who = "Tech";     // This is needed for group resolution
+        row.helpers.value = "";
+        row.helpers.tokens = [];
+
+        // Provide a metadata object with a fixed id
+        const rowId = randomstring.generate();
+        const metadata = getRandomlyGeneratedMetadata();
+        metadata.getValue = jest.fn(() => rowId);
+        row.metadata = metadata;
+
+        // Initial save – should store a hash based on current group members (John + Jane)
+        saveRow(row, {}, undefined);
+        expect(hasChanged(row)).toBe(false);
+
+        // Update group membership to include a new member
+        groupMap["tech"] = ["john doe", "jane smith", "bob wilson"];
+
+        // Now the hash input should differ since the group resolves to different members
+        expect(hasChanged(row)).toBe(true);
+    });
+
+    it("should return false when group membership is unchanged", () => {
+        // Mutable map so we can simulate updates to group membership after the row is saved
+        const groupMap: { [name: string]: string[] } = { 
+            "tech": ["john doe", "jane smith"]
+        };
+
+        // Static person → id mapping
+        const personIdMap: { [name: string]: string } = {
+            "john doe": "id1",
+            "jane smith": "id2",
+            "bob wilson": "id3"
+        };
+
+        jest.doMock("../src/main/people", () => ({
+            getPersonId: (name: string) => personIdMap[name.toLowerCase()],
+            normalizePersonName: (name: string) => name.toLowerCase().trim(),
+        }));
+
+        jest.doMock("../src/main/aliases", () => ({ ALIASES_MAP: {} }));
+
+        jest.doMock("../src/main/groups", () => ({
+            GROUPS_MAP: groupMap,
+            getMembersFromGroups: (groups: string[]) => {
+                return groups.flatMap(g => groupMap[g.toLowerCase()] || []);
+            },
+            GROUP_NAMES: ["tech"],
+        }));
+
+        jest.doMock("../src/main/filter", () => ({
+            containsFilter: () => false,
+            removeFilters: (str: string) => ({ stringWithoutFilters: str, removedFilters: [] }),
+            filterMembers: (members: string[]) => members,
+            isFilter: () => false,
+        }));
+
+        // PropertiesService mock that lets us capture what saveRow writes and return it later
+        let storedRowBasecampMapping: string | null = null;
+        jest.doMock("../src/main/propertiesService", () => ({
+            setDocumentProperty: (_k: string, v: string) => {
+                storedRowBasecampMapping = v;
+            },
+            getDocumentProperty: () => storedRowBasecampMapping,
+            loadMapFromScriptProperties: () => ({}),
+        }));
+
+        // Import module under test AFTER mocks are in place
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { saveRow, hasChanged } = require("../src/main/row");
+
+        // Construct a deterministic row with a group as lead
+        const row: Row = getRandomlyGeneratedRow();
+        row.inCharge.value = "Tech";
+        row.inCharge.tokens = [{ value: "Tech", hyperlink: null, strikethrough: false }];
+        row.domain = "Tech";  // This is needed for group resolution
+        row.who = "Tech";     // This is needed for group resolution
+        row.helpers.value = "";
+        row.helpers.tokens = [];
+
+        // Provide a metadata object with a fixed id
+        const rowId = randomstring.generate();
+        const metadata = getRandomlyGeneratedMetadata();
+        metadata.getValue = jest.fn(() => rowId);
+        row.metadata = metadata;
+
+        // Initial save – should store a hash based on current group members
+        saveRow(row, {}, undefined);
+        expect(hasChanged(row)).toBe(false);
+
+        // Reassign same members in different order - should still be false since we sort
+        groupMap["tech"] = ["jane smith", "john doe"];
+        expect(hasChanged(row)).toBe(false);
+
+        // Even assigning the exact same array should be false
+        groupMap["tech"] = ["john doe", "jane smith"];
+        expect(hasChanged(row)).toBe(false);
+    });
+
+    it("should return true when attendee resolution changes", () => {
+        // Mutable map so we can simulate updates to group membership after the row is saved
+        const groupMap: { [name: string]: string[] } = { 
+            "hg1": ["alice", "bob", "charlie"],
+            "hg2": ["david", "eve"]
+        };
+
+        // Static person → id mapping
+        const personIdMap: { [name: string]: string } = {
+            "alice": "id1",
+            "bob": "id2",
+            "charlie": "id3",
+            "david": "id4",
+            "eve": "id5",
+            "frank": "id6"
+        };
+
+        jest.doMock("../src/main/people", () => ({
+            getPersonId: (name: string) => personIdMap[name.toLowerCase()],
+            normalizePersonName: (name: string) => name.toLowerCase().trim(),
+        }));
+
+        jest.doMock("../src/main/aliases", () => ({ ALIASES_MAP: {} }));
+
+        jest.doMock("../src/main/groups", () => ({
+            GROUPS_MAP: groupMap,
+            getMembersFromGroups: (groups: string[]) => {
+                return groups.flatMap(g => groupMap[g.toLowerCase()] || []);
+            },
+            GROUP_NAMES: ["hg1", "hg2"],
+        }));
+
+        jest.doMock("../src/main/filter", () => ({
+            containsFilter: () => false,
+            removeFilters: (str: string) => ({ stringWithoutFilters: str, removedFilters: [] }),
+            filterMembers: (members: string[]) => members,
+            isFilter: () => false,
+        }));
+
+        // PropertiesService mock that lets us capture what saveRow writes and return it later
+        let storedRowBasecampMapping: string | null = null;
+        jest.doMock("../src/main/propertiesService", () => ({
+            setDocumentProperty: (_k: string, v: string) => {
+                storedRowBasecampMapping = v;
+            },
+            getDocumentProperty: () => storedRowBasecampMapping,
+            loadMapFromScriptProperties: () => ({}),
+        }));
+
+        // Import module under test AFTER mocks are in place
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { saveRow, hasChanged } = require("../src/main/row");
+
+        // Construct a deterministic row with ministry groups in the who column
+        const row: Row = getRandomlyGeneratedRow();
+        row.who = "HG1,HG2";     // This should resolve to all members of both groups
+        row.domain = "HG1,HG2";  // This is needed for group resolution
+        row.inCharge.value = "Frank";  // Single lead not affected by group changes
+        row.inCharge.tokens = [{ value: "Frank", hyperlink: null, strikethrough: false }];
+        row.helpers.value = "";
+        row.helpers.tokens = [];
+
+        // Provide a metadata object with a fixed id
+        const rowId = randomstring.generate();
+        const metadata = getRandomlyGeneratedMetadata();
+        metadata.getValue = jest.fn(() => rowId);
+        row.metadata = metadata;
+
+        // Initial save – should store a hash based on current group members
+        saveRow(row, {}, undefined);
+        expect(hasChanged(row)).toBe(false);
+
+        // Update SWS group membership
+        groupMap["hg1"] = ["alice", "bob", "charlie", "frank"];  // Added Frank
+
+        // Now the hash input should differ since attendees resolve differently
+        expect(hasChanged(row)).toBe(true);
+    });
+
+    it("should return false when attendee resolution is unchanged", () => {
+        // Mutable map so we can simulate updates to group membership after the row is saved
+        const groupMap: { [name: string]: string[] } = { 
+            "hg1": ["alice", "bob", "charlie"],
+            "hg2": ["david", "eve"]
+        };
+
+        // Static person → id mapping
+        const personIdMap: { [name: string]: string } = {
+            "alice": "id1",
+            "bob": "id2",
+            "charlie": "id3",
+            "david": "id4",
+            "eve": "id5",
+            "frank": "id6"
+        };
+
+        jest.doMock("../src/main/people", () => ({
+            getPersonId: (name: string) => personIdMap[name.toLowerCase()],
+            normalizePersonName: (name: string) => name.toLowerCase().trim(),
+        }));
+
+        jest.doMock("../src/main/aliases", () => ({ ALIASES_MAP: {} }));
+
+        jest.doMock("../src/main/groups", () => ({
+            GROUPS_MAP: groupMap,
+            getMembersFromGroups: (groups: string[]) => {
+                return groups.flatMap(g => groupMap[g.toLowerCase()] || []);
+            },
+            GROUP_NAMES: ["hg1", "hg2"],
+        }));
+
+        jest.doMock("../src/main/filter", () => ({
+            containsFilter: () => false,
+            removeFilters: (str: string) => ({ stringWithoutFilters: str, removedFilters: [] }),
+            filterMembers: (members: string[]) => members,
+            isFilter: () => false,
+        }));
+
+        // PropertiesService mock that lets us capture what saveRow writes and return it later
+        let storedRowBasecampMapping: string | null = null;
+        jest.doMock("../src/main/propertiesService", () => ({
+            setDocumentProperty: (_k: string, v: string) => {
+                storedRowBasecampMapping = v;
+            },
+            getDocumentProperty: () => storedRowBasecampMapping,
+            loadMapFromScriptProperties: () => ({}),
+        }));
+
+        // Import module under test AFTER mocks are in place
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { saveRow, hasChanged } = require("../src/main/row");
+
+        // Construct a deterministic row with ministry groups in the who column
+        const row: Row = getRandomlyGeneratedRow();
+        row.who = "HG1,HG2";     // This should resolve to all members of both groups
+        row.domain = "HG1,HG2";  // This is needed for group resolution
+        row.inCharge.value = "Frank";  // Single lead not affected by group changes
+        row.inCharge.tokens = [{ value: "Frank", hyperlink: null, strikethrough: false }];
+        row.helpers.value = "";
+        row.helpers.tokens = [];
+
+        // Provide a metadata object with a fixed id
+        const rowId = randomstring.generate();
+        const metadata = getRandomlyGeneratedMetadata();
+        metadata.getValue = jest.fn(() => rowId);
+        row.metadata = metadata;
+
+        // Initial save – should store a hash based on current group members
+        saveRow(row, {}, undefined);
+        expect(hasChanged(row)).toBe(false);
+
+        // Reassign same members in different order - should still be false since we sort
+        groupMap["hg1"] = ["charlie", "alice", "bob"];
+        groupMap["hg2"] = ["eve", "david"];
+        expect(hasChanged(row)).toBe(false);
+
+        // Even assigning the exact same arrays should be false
+        groupMap["hg1"] = ["alice", "bob", "charlie"];
+        groupMap["hg2"] = ["david", "eve"];
+        expect(hasChanged(row)).toBe(false);
+    });
+}); 

--- a/src/main/row.ts
+++ b/src/main/row.ts
@@ -25,6 +25,47 @@ const BASECAMP_COL_INDEX: number = 11;
 const BASECAMP_LINK_TEXT: string = "Link";
 
 /**
+ * Builds the string representation used when computing the row hash.  In addition to the raw
+ * string representation of the row (see toString(row)), this now also includes the list of
+ * Basecamp ids that are derived from the row (leads, helpers and any other attendees).
+ * 
+ * The attendees list is first resolved to Basecamp ids and sorted to ensure determinism so that
+ * the same logical set of attendees will always result in the same hash value regardless of the
+ * original ordering in the sheet.  By incorporating the resolved ids we ensure that any change
+ * in the way names are mapped to ids (e.g. changes to aliases, people map, groups, etc.) will
+ * be detected by hasChanged().
+ * 
+ * @param row the row to generate the hashable representation for
+ * @returns a deterministic string containing the row contents and the resolved attendee ids
+ */
+function getHashableRowRepresentation(row: Row): string {
+    // The base string representation (sheet values)
+    const baseRowString: string = toString(row);
+
+    // Resolve attendees (includes leads & helpers) as well as the explicit lead / helper lists 
+    // to Basecamp ids so that ANY mapping change is reflected in the hash.
+
+    const attendeeIds: string[] = getBasecampIdsFromPersonNameList(getAttendeesFromRow(row));
+    const leadIds: string[] = getLeadsBasecampIds(row);
+    const helperIds: string[] = getHelperGroups(row).flatMap(group => group.helperIds);
+
+    // Sort to guarantee stable ordering before hashing
+    attendeeIds.sort();
+    leadIds.sort();
+    helperIds.sort();
+
+    const hashPayload = {
+        attendeeIds: attendeeIds,
+        leadIds: leadIds,
+        helperIds: helperIds,
+    };
+
+    // Combine – use a character that cannot appear in baseRowString ("|" is safe given current
+    // toString implementation) to avoid ambiguity
+    return `${baseRowString}|${JSON.stringify(hashPayload)}`;
+}
+
+/**
  * Retrieves the metadata object for a given range. If the metadata object does not exist,
  * this function will set the row id key so the metadata object is created and a reference
  * can be held
@@ -101,7 +142,8 @@ export function saveRow(row: Row, roleTodoMap: RoleTodoMap, scheduleEntryId: str
     }
 
     const rowId: string = getId(row);
-    const rowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, toString(row)));
+    const rowHashInput: string = getHashableRowRepresentation(row);
+    const rowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, rowHashInput));
     const tabInfo: TabInfo = { date: row.date };
     const rowBasecampMapping: RowBasecampMapping = {rowHash: rowHash, roleTodoMap: roleTodoMap, scheduleEntryId: scheduleEntryId, tabInfo: tabInfo};
 
@@ -145,7 +187,8 @@ export function hasChanged(row: Row): boolean {
         throw new RowNotSavedError(`Row has not yet been saved: ${toString(row)}`);
     }
 
-    const currentRowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, toString(row)));
+    const currentRowHashInput: string = getHashableRowRepresentation(row);
+    const currentRowHash: string = toHexString(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, currentRowHashInput));
     const storedRowHash: string | null = getSavedHash(row);
 
     // null check to catch cases where the hashes are null (although this shouldn't be the case)


### PR DESCRIPTION
whenever ppl change groups, we need a forceUpdate to have it take effect b/c the row hash only saves the row string representation, which doesn't include how groups or other aliases are resolved into individual people.
by saving the full resolution of groups and aliases in the row hash, we can detect all changes automatically.